### PR TITLE
68 metamask demo

### DIFF
--- a/modules/wallet/src/App.js
+++ b/modules/wallet/src/App.js
@@ -130,7 +130,7 @@ class App extends Component {
   }
 
   async setWalletAndProvider(metamask = false) {
-    this.setState({ authorized: false });
+    this.setState({ authorized: false, usingMetamask: metamask });
     let web3;
     let address;
     // get metamask address defaults
@@ -914,6 +914,7 @@ class App extends Component {
                 tokenContract={this.state.tokenContract}
                 humanTokenAbi={humanTokenAbi}
                 connext={this.state.connext}
+                usingMetamask={this.state.usingMetamask}
               />
             </div>
             <div className="column">


### PR DESCRIPTION
## Description
Deposit handler now calls `connext.deposit` in deposit card if using metamask

## Motivation and Context
Metamask requires a different flow than the autosigner for deposits. Now addressed.

## How Has This Been Tested?
Local testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
