### PR TITLE
Dankinsley bugfix signer

### DIFF
--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connext",
   "description": "Shared code between wallet and hub",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {

--- a/modules/client/src/Wallet.ts
+++ b/modules/client/src/Wallet.ts
@@ -42,13 +42,13 @@ export default class Wallet extends eth.Signer {
     // First choice: Sign w private key
     if (opts.privateKey) {
       this.signer = new eth.Wallet(opts.privateKey || '')
-      this.signer.connect(this.provider)
+      this.signer = this.signer.connect(this.provider)
       this.address = this.signer.address.toLowerCase()
 
     // Second choice: Sign w mnemonic
     } else if (opts.mnemonic) {
       this.signer = eth.Wallet.fromMnemonic(opts.mnemonic || '')
-      this.signer.connect(this.provider)
+      this.signer = this.signer.connect(this.provider)
       this.address = this.signer.address.toLowerCase()
 
     // Third choice: Sign w web3
@@ -60,7 +60,7 @@ export default class Wallet extends eth.Signer {
     // Default: create new random mnemonic
     } else {
       this.signer = eth.Wallet.createRandom()
-      this.signer.connect(this.provider)
+      this.signer = this.signer.connect(this.provider)
       this.address = this.signer.address.toLowerCase()
       console.warn(`Generated a new signing key, make sure you back it up before sending funds`)
     }
@@ -121,6 +121,9 @@ export default class Wallet extends eth.Signer {
   }
 
   async sendTransaction(txReq: TransactionRequest): Promise<TransactionResponse> {
+    if (txReq.nonce == null) {
+      txReq.nonce = this.signer!.getTransactionCount("pending"); 
+    }
     // TransactionRequest properties can be promises, make sure they've all resolved
     const tx = await objMapPromise(txReq, async (k, v) => await v) as any
 

--- a/modules/client/src/contract/ChannelManager.ts
+++ b/modules/client/src/contract/ChannelManager.ts
@@ -78,6 +78,7 @@ export class ChannelManager implements IChannelManager {
   async _send(method: string, args: any, overrides: any) {
     const gasEstimate = (await this.cm.estimate[method](...args, overrides)).toNumber()
     overrides.gasLimit = eth.utils.bigNumberify(Math.ceil(gasEstimate * this.gasMultiple))
+    overrides.gasPrice = await this.provider.getGasPrice()
     return await this.cm[method](...args, overrides)
   }
 

--- a/modules/client/src/controllers/DepositController.ts
+++ b/modules/client/src/controllers/DepositController.ts
@@ -134,6 +134,7 @@ export default class DepositController extends AbstractController {
         const overrides: any = { }
         const gasEstimate = (await token.estimate.approve(prev.contractAddress, args.depositTokenUser)).toNumber()
         overrides.gasLimit = eth.utils.bigNumberify(Math.ceil(gasEstimate * this.connext.contract.gasMultiple))
+        overrides.gasPrice = await this.connext.wallet.provider.getGasPrice()
         const tx = await token.approve(prev.contractAddress, args.depositTokenUser, overrides)
         await this.connext.wallet.provider.waitForTransaction(tx.hash)
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indra",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Connext & Friends",
   "description": "Deployment for Connext hub infrastructure",
   "license": "ISC",


### PR DESCRIPTION
## The Problem
See closed PR #201 . Added to properly run through the CI while settings from forks are in flux. Original problem statement:

I am initializing Connext with a privateKey string, first using ganache-cli, then using Rinkeby Infura RPC.
On Ganache, I kept encountering "invalid nonce" errors, so then I gave up and thought it was a ganache issue, so I tried Rinkeby. On Rinkeby I was seeing "transaction underpriced" errors.

## The Solution
After setting the gas price it fixed the "transaction underpriced" issues, but then I received nonce issues on Rinkeby. I then noticed that the connext Wallet class is overriding the Signer, so I looked at the implementation of Wallet in ethers and noticed it was setting the nonce there, but not in the Connext inherited version.
https://github.com/ethers-io/ethers.js/blob/master/src.ts/wallet.ts#L95

Adding the nonce fixed the Rinkeby issues, and I presume would have fixed my ganache issues as well.

I have only been testing the Deposit function, so I presume other methods are still broken.

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [x] I have incremented the version in the project root's package.json
- [x] The commit that increments the version includes the new version number in it's commit message
- [x] My code follows the code style of this project.
- [ ] This code has passed all CI tests & has been deployed successfully to staging.
- [ ] I have verified that, the staging site reflected these changes and worked as expected.
- [x] I have described any backwards-incompatibility implications above.
- [x] I have highlighted which parts of the code should be reviewed most carefully.
- [x] If my change requires a change to the documentation, I have updated it accordingly.