### PR TITLE
Add basic support for `FORCE_SSL`

### DIFF
--- a/modules/hub/package.json
+++ b/modules/hub/package.json
@@ -48,6 +48,7 @@
     "path-to-regexp": "^3.0.0",
     "pg": "^7.9.0",
     "pg-types": "^2.0.1",
+    "selfsigned": "^1.10.4",
     "sql-template-strings": "^2.2.2",
     "uuid": "^3.3.2",
     "web3": "1.0.0-beta.52"

--- a/modules/hub/src/Config.ts
+++ b/modules/hub/src/Config.ts
@@ -10,6 +10,7 @@ const ENV_VARS = [
   'AUTH_REALM',
   'AUTH_DOMAIN_WHITELIST',
   'PORT',
+  'HTTPS_PORT',
   'SHOULD_COLLATERALIZE_URL',
   'MIN_SETTLEMENT_PERIOD',
   'RECIPIENT_WHITELIST',
@@ -18,6 +19,7 @@ const ENV_VARS = [
   'CARD_IMAGE_URL',
   'REALTIME_DB_SECRET', // TODO: do we use this?
   'SERVICE_USER_KEY',
+  'FORCE_SSL',
   'REDIS_URL',
   'TOKEN_CONTRACT_ADDRESS',
   'HOT_WALLET_ADDRESS',
@@ -74,6 +76,7 @@ export default class Config {
   public adminAddresses?: string[] = []
   public serviceUserKey: string = 'omqGMZzn90vFJskXFxzuO3gYHM6M989spw99f3ngRSiNSOUdB0PmmYTvZMByUKD'
   public port: number = 8080
+  public httpsPort: number = 8443
   // URL used to check whether a user should receive collateral.
   // Called by ChannelsService.shouldCollateralize:
   //
@@ -85,6 +88,7 @@ export default class Config {
   //
   // If the value is 'NO_CHECK' then no check will be performed.
   public shouldCollateralizeUrl: string | 'NO_CHECK' = 'NO_CHECK'
+  public forceSsl: boolean | false = process.env.FORCE_SSL && process.env.FORCE_SSL.toLowerCase() === 'true'
   public recipientAddress: string = ''
   public hotWalletAddress: string = ''
   public hotWalletMinBalance: string = toWei('6.9').toString()


### PR DESCRIPTION
<!--- Make sure your title is descriptive -->
<!--- If you have any questions, don't hesitate to reach out to us on Discord! -->

## The Problem
Currently, connections to the hub API's express server can only be made over HTTP on port 8080. Terminating connections using SSL would be preferred in certain cases, like when using a custom upstream proxy instead of the indra-packaged nginx proxy.

## The Solution
When `FORCE_SSL` environment variable is set to `true`, connections to the hub API's express server are terminated using SSL. This will break existing implementations that use the nginx proxy, so should be used only in certain conditions.

In the future we can enhance this to use configured certificates in the environment, use this as a place to add support for client auth, etc.

I have tested this on a different branch. Works...

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I have incremented the version in the project root's package.json
- [ ] The commit that increments the version includes the new version number in it's commit message
- [ ] My code follows the code style of this project.
- [ ] This code has passed all CI tests & has been deployed successfully to staging.
- [ ] I have verified that, the staging site reflected these changes and worked as expected.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
