### PR TITLE
Add commandline fetch events from block range

### DIFF
--- a/modules/contracts/package-lock.json
+++ b/modules/contracts/package-lock.json
@@ -3770,7 +3770,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.33",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {

--- a/modules/dashboard/package-lock.json
+++ b/modules/dashboard/package-lock.json
@@ -7086,7 +7086,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7123,7 +7124,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -7132,7 +7134,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7235,7 +7238,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7245,6 +7249,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7257,17 +7262,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7284,6 +7292,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7356,7 +7365,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7366,6 +7376,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7441,7 +7452,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7471,6 +7483,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7488,6 +7501,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7526,11 +7540,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }

--- a/modules/hub/src/PaymentHub.ts
+++ b/modules/hub/src/PaymentHub.ts
@@ -119,6 +119,12 @@ export default class PaymentHub {
     await chainsaw.processSingleTx(txHash, true)
   }
 
+  public async fetchEventsFromBlock(startingBlock: number, endingBlock: number) {
+    const chainsaw = this.container.resolve<ChainsawService>('ChainsawService')
+    this.log.info(`Fetching events from: ${startingBlock} to ${endingBlock}`);
+    await chainsaw.doFetchEventsFromRange(startingBlock, endingBlock);
+  }
+
   public async collateralizeChannel(user: string, amount: BN) {
     const context = new Context()
     const channelsService = this.container.resolve<ChannelsService>('ChannelsService', { 'Context': context })

--- a/modules/hub/src/spankchain/main.ts
+++ b/modules/hub/src/spankchain/main.ts
@@ -23,6 +23,7 @@ async function run(): Promise<void> {
     'fix-channels': (args: string[]): Promise<void> => hub.fixBrokenChannels(),
     'hub': (args: string[]): Promise<any> => hub.start(),
     'process-tx': (args: string[]): Promise<void> => hub.processTx(args[0]),
+    'process-blocks': (args: string[]): Promise<void> => hub.fetchEventsFromBlock(+args[0], +args[1])
   }
 
   const cmd = process.argv[2] || 'hub'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indra",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "author": "Connext & Friends",
   "description": "Deployment for Connext hub infrastructure",
   "license": "ISC",


### PR DESCRIPTION
## The Problem
`process-tx` wont work if theres no chainsaw event in the db matching the hash provided. Need a way to reprocess events from within a given block range.

## The Solution
Commandline reprocessing of events from block within a range by chainsaw

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [x] I have incremented the version in the project root's package.json
- [x] The commit that increments the version includes the new version number in it's commit message
- [x] My code follows the code style of this project.
- [x] This code has passed all CI tests & has been deployed successfully to staging.
- [ ] I have verified that, the staging site reflected these changes and worked as expected.
- [x] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

Hot fix command line stuff, probably should've used the `deploy-indra.sh` script. Need it now unfortunately.
