### PR TITLE
Move action encoding to correct app

### DIFF
--- a/modules/node/src/config/config.service.ts
+++ b/modules/node/src/config/config.service.ts
@@ -92,11 +92,6 @@ export class ConfigService implements OnModuleInit {
     const addressBook = await this.getContractAddresses();
     return [
       {
-        actionEncoding: `
-          tuple(
-            uint8 actionType,
-            uint256 amount
-          )`,
         allowNodeInstall: false,
         appDefinitionAddress: addressBook[SupportedApplications.SimpleTransferApp],
         name: SupportedApplications.SimpleTransferApp,
@@ -108,6 +103,11 @@ export class ConfigService implements OnModuleInit {
           )`,
       },
       {
+        actionEncoding: `
+          tuple(
+            uint8 actionType,
+            uint256 amount
+          )`,
         allowNodeInstall: false,
         appDefinitionAddress: addressBook[SupportedApplications.UnidirectionalTransferApp],
         name: SupportedApplications.UnidirectionalTransferApp,


### PR DESCRIPTION
## The Problem
#263 Action encoding is on the wrong app in the config registry.

## The Solution
Fix the problem.

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] This code has passed all CI tests & has been deployed successfully to staging.
- [ ] I have verified that, the staging site reflected these changes and worked as expected.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.