### PR TITLE
591 logical timing

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "defaultCommandTimeout": 180000,
+  "defaultCommandTimeout": 270000,
   "env": {
     "mnemonic": "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat",
     "provider": "/api/ethprovider",

--- a/modules/cf-adjudicator-contracts/package.json
+++ b/modules/cf-adjudicator-contracts/package.json
@@ -21,7 +21,7 @@
     "solidity"
   ],
   "devDependencies": {
-    "@connext/cf-types": "1.2.17",
+    "@connext/cf-types": "1.2.18",
     "@types/node": "12.12.7",
     "@types/chai": "4.2.4",
     "chai": "4.2.0",

--- a/modules/cf-adjudicator-contracts/package.json
+++ b/modules/cf-adjudicator-contracts/package.json
@@ -21,7 +21,7 @@
     "solidity"
   ],
   "devDependencies": {
-    "@connext/cf-types": "1.2.16",
+    "@connext/cf-types": "1.2.17",
     "@types/node": "12.12.7",
     "@types/chai": "4.2.4",
     "chai": "4.2.0",

--- a/modules/cf-apps/package.json
+++ b/modules/cf-apps/package.json
@@ -17,7 +17,7 @@
     "lint:ts": "tslint -c tslint.json -p ."
   },
   "devDependencies": {
-    "@connext/cf-types": "1.2.17",
+    "@connext/cf-types": "1.2.18",
     "@connext/cf-adjudicator-contracts": "0.4.1",
     "@types/chai": "4.2.4",
     "@types/mocha": "5.2.7",

--- a/modules/cf-apps/package.json
+++ b/modules/cf-apps/package.json
@@ -17,7 +17,7 @@
     "lint:ts": "tslint -c tslint.json -p ."
   },
   "devDependencies": {
-    "@connext/cf-types": "1.2.16",
+    "@connext/cf-types": "1.2.17",
     "@connext/cf-adjudicator-contracts": "0.4.1",
     "@types/chai": "4.2.4",
     "@types/mocha": "5.2.7",

--- a/modules/cf-core/package.json
+++ b/modules/cf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/cf-core",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "main": "dist/src/index.js",
   "iife": "dist/src/index.iife.js",
   "types": "dist/src/index.d.ts",
@@ -19,7 +19,7 @@
   "dependencies": {
     "@connext/cf-adjudicator-contracts": "0.4.1",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
-    "@connext/types": "1.2.17",
+    "@connext/types": "1.2.18",
     "@counterfactual/cf-adjudicator-contracts": "0.0.9",
     "@counterfactual/cf-funding-protocol-contracts": "0.0.12",
     "ethers": "4.0.39",
@@ -33,8 +33,8 @@
   "devDependencies": {
     "@babel/core": "7.7.2",
     "@babel/plugin-proposal-object-rest-spread": "7.6.2",
-    "@connext/cf-types": "1.2.17",
-    "@connext/types": "1.2.17",
+    "@connext/cf-types": "1.2.18",
+    "@connext/types": "1.2.18",
     "@counterfactual/local-ganache-server": "0.0.10",
     "@counterfactual/postgresql-node-connector": "0.0.8",
     "@types/chai": "4.2.4",

--- a/modules/cf-core/package.json
+++ b/modules/cf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/cf-core",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "main": "dist/src/index.js",
   "iife": "dist/src/index.iife.js",
   "types": "dist/src/index.d.ts",
@@ -19,7 +19,7 @@
   "dependencies": {
     "@connext/cf-adjudicator-contracts": "0.4.1",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
-    "@connext/types": "1.2.16",
+    "@connext/types": "1.2.17",
     "@counterfactual/cf-adjudicator-contracts": "0.0.9",
     "@counterfactual/cf-funding-protocol-contracts": "0.0.12",
     "ethers": "4.0.39",
@@ -33,8 +33,8 @@
   "devDependencies": {
     "@babel/core": "7.7.2",
     "@babel/plugin-proposal-object-rest-spread": "7.6.2",
-    "@connext/cf-types": "1.2.16",
-    "@connext/types": "1.2.16",
+    "@connext/cf-types": "1.2.17",
+    "@connext/types": "1.2.17",
     "@counterfactual/local-ganache-server": "0.0.10",
     "@counterfactual/postgresql-node-connector": "0.0.8",
     "@types/chai": "4.2.4",

--- a/modules/cf-core/src/constants.ts
+++ b/modules/cf-core/src/constants.ts
@@ -1,6 +1,7 @@
 import { AddressZero } from "ethers/constants";
 
-// Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read
+// Adds indentation, white space, and line break characters to the return-value
+// JSON text to make it easier to read
 export const JSON_STRINGIFY_SPACE = 2;
 
 /**
@@ -15,3 +16,7 @@ export const CONVENTION_FOR_ETH_TOKEN_ADDRESS = AddressZero;
 
 // 25446 is 0x6366... or "cf" in ascii, for "Counterfactual".
 export const CF_PATH = "m/44'/60'/0'/25446";
+
+// 1 messaging timeout there, 1 messaging timeout back
+// assume messaging timeout of 15s
+export const IO_SEND_AND_WAIT_TIMEOUT = 30_000;

--- a/modules/cf-core/src/node.ts
+++ b/modules/cf-core/src/node.ts
@@ -12,11 +12,11 @@ import { StateChannel } from "./models";
 import { getFreeBalanceAddress } from "./models/free-balance";
 import {
   EthereumNetworkName,
-  getNetworkContextForNetworkName,
+  getNetworkContextForNetworkName
 } from "./network-configuration";
 import {
   getPrivateKeysGeneratorAndXPubOrThrow,
-  PrivateKeysGetter,
+  PrivateKeysGetter
 } from "./private-keys-generator";
 import ProcessQueue from "./process-queue";
 import { RequestHandler } from "./request-handler";
@@ -25,9 +25,10 @@ import {
   NetworkContext,
   Node as NodeTypes,
   NODE_EVENTS,
-  NodeMessageWrappedProtocolMessage,
+  NodeMessageWrappedProtocolMessage
 } from "./types";
 import { timeout } from "./utils";
+import { IO_SEND_AND_WAIT_TIMEOUT } from "./constants";
 
 export interface NodeConfig {
   // The prefix for any keys used in the store by this Node depends on the
@@ -220,7 +221,10 @@ export class Node {
         } as NodeMessageWrappedProtocolMessage);
 
         // 90 seconds is the default lock acquiring time time
-        const msg = await Promise.race([counterpartyResponse, timeout(90000)]);
+        const msg = await Promise.race([
+          counterpartyResponse,
+          timeout(IO_SEND_AND_WAIT_TIMEOUT)
+        ]);
 
         if (!msg || !("data" in (msg as NodeMessageWrappedProtocolMessage))) {
           throw Error(

--- a/modules/cf-core/src/process-queue.ts
+++ b/modules/cf-core/src/process-queue.ts
@@ -2,6 +2,7 @@ import Queue, { Task } from "p-queue";
 
 import { addToManyQueues } from "./methods/queued-execution";
 import { Node } from "./types";
+import { IO_SEND_AND_WAIT_TIMEOUT } from "./constants";
 
 class QueueWithLockingServiceConnection extends Queue {
   constructor(
@@ -12,9 +13,16 @@ class QueueWithLockingServiceConnection extends Queue {
     super(...args);
   }
 
+  // timeout should be 3 * IO_SEND_AND_WAIT to account
+  // for worst case messaging scenario in virtual install
+  // protocol (3 IO_SEND_AND_WAITs each with a 30s timer)
   async add(task: Task<any>) {
     return super.add(() =>
-      this.lockingService.acquireLock(this.lockName, task, 30_000)
+      this.lockingService.acquireLock(
+        this.lockName,
+        task,
+        IO_SEND_AND_WAIT_TIMEOUT * 3
+      )
     );
   }
 }

--- a/modules/cf-types/package.json
+++ b/modules/cf-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/cf-types",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "TypeScript typings for common Counterfactual types",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/modules/cf-types/package.json
+++ b/modules/cf-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/cf-types",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "TypeScript typings for common Counterfactual types",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/client",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Shared code between wallet and node",
   "main": "dist/index.js",
   "files": ["dist", "src", "types"],
@@ -12,10 +12,10 @@
     "test": "./node_modules/.bin/jest"
   },
   "dependencies": {
-    "@connext/cf-core": "1.2.16",
+    "@connext/cf-core": "1.2.17",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
-    "@connext/messaging": "1.2.16",
-    "@connext/types": "1.2.16",
+    "@connext/messaging": "1.2.17",
+    "@connext/types": "1.2.17",
     "core-js": "3.4.0",
     "eth-crypto": "1.5.0",
     "ethers": "4.0.39",

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/client",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Shared code between wallet and node",
   "main": "dist/index.js",
   "files": ["dist", "src", "types"],
@@ -12,10 +12,10 @@
     "test": "./node_modules/.bin/jest"
   },
   "dependencies": {
-    "@connext/cf-core": "1.2.17",
+    "@connext/cf-core": "1.2.18",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
-    "@connext/messaging": "1.2.17",
-    "@connext/types": "1.2.17",
+    "@connext/messaging": "1.2.18",
+    "@connext/types": "1.2.18",
     "core-js": "3.4.0",
     "eth-crypto": "1.5.0",
     "ethers": "4.0.39",

--- a/modules/client/src/controllers/ConditionalTransferController.ts
+++ b/modules/client/src/controllers/ConditionalTransferController.ts
@@ -226,7 +226,10 @@ export class ConditionalTransferController extends AbstractController {
           );
           this.listener.on(CFCoreTypes.EventName.REJECT_INSTALL, boundReject);
         }),
-        delayAndThrow(CF_METHOD_TIMEOUT, "App install took longer than 15 seconds"),
+        delayAndThrow(
+          CF_METHOD_TIMEOUT,
+          `App install took longer than ${CF_METHOD_TIMEOUT / 1000} seconds`,
+        ),
       ]);
       this.log.info(`App was installed successfully!: ${stringify(raceRes as object)}`);
       return proposeRes.appInstanceId;

--- a/modules/client/src/controllers/ConditionalTransferController.ts
+++ b/modules/client/src/controllers/ConditionalTransferController.ts
@@ -2,6 +2,7 @@ import EthCrypto from "eth-crypto";
 import { HashZero, Zero } from "ethers/constants";
 import { fromExtendedKey } from "ethers/utils/hdnode";
 
+import { CF_METHOD_TIMEOUT } from "../lib/constants";
 import { createLinkedHash, delayAndThrow, stringify, xpubToAddress } from "../lib/utils";
 import {
   BigNumber,
@@ -225,7 +226,7 @@ export class ConditionalTransferController extends AbstractController {
           );
           this.listener.on(CFCoreTypes.EventName.REJECT_INSTALL, boundReject);
         }),
-        delayAndThrow(15_000, "App install took longer than 15 seconds"),
+        delayAndThrow(CF_METHOD_TIMEOUT, "App install took longer than 15 seconds"),
       ]);
       this.log.info(`App was installed successfully!: ${stringify(raceRes as object)}`);
       return proposeRes.appInstanceId;

--- a/modules/client/src/controllers/DepositController.ts
+++ b/modules/client/src/controllers/DepositController.ts
@@ -152,7 +152,10 @@ export class DepositController extends AbstractController {
           console.warn(`waiting for proposal acceptance of ${appInstanceId}`);
           this.listener.on(CFCoreTypes.EventName.REJECT_INSTALL, boundReject);
         }),
-        delayAndThrow(CF_METHOD_TIMEOUT, "App install took longer than 15 seconds"),
+        delayAndThrow(
+          CF_METHOD_TIMEOUT,
+          `App install took longer than ${CF_METHOD_TIMEOUT / 1000} seconds`,
+        ),
       ]);
       this.log.info(`App was proposed successfully!: ${appId}`);
       return undefined;

--- a/modules/client/src/controllers/DepositController.ts
+++ b/modules/client/src/controllers/DepositController.ts
@@ -2,6 +2,7 @@ import { Contract } from "ethers";
 import { AddressZero, Zero } from "ethers/constants";
 import tokenAbi from "human-standard-token-abi";
 
+import { CF_METHOD_TIMEOUT } from "../lib/constants";
 import { delayAndThrow, stringify, xpubToAddress } from "../lib/utils";
 import {
   BigNumber,
@@ -151,7 +152,7 @@ export class DepositController extends AbstractController {
           console.warn(`waiting for proposal acceptance of ${appInstanceId}`);
           this.listener.on(CFCoreTypes.EventName.REJECT_INSTALL, boundReject);
         }),
-        delayAndThrow(15_000, "App install took longer than 15 seconds"),
+        delayAndThrow(CF_METHOD_TIMEOUT, "App install took longer than 15 seconds"),
       ]);
       this.log.info(`App was proposed successfully!: ${appId}`);
       return undefined;

--- a/modules/client/src/controllers/RequestDepositRightsController.ts
+++ b/modules/client/src/controllers/RequestDepositRightsController.ts
@@ -211,7 +211,10 @@ export class RequestDepositRightsController extends AbstractController {
           this.log.info(`waiting for proposal acceptance of ${appInstanceId}`);
           this.listener.on(CFCoreTypes.EventName.REJECT_INSTALL, boundReject);
         }),
-        delayAndThrow(CF_METHOD_TIMEOUT, "App install took longer than 15 seconds"),
+        delayAndThrow(
+          CF_METHOD_TIMEOUT,
+          `App install took longer than ${CF_METHOD_TIMEOUT / 1000} seconds`,
+        ),
       ]);
       this.log.info(`App was proposed successfully!: ${appId}`);
       return undefined;

--- a/modules/client/src/controllers/RequestDepositRightsController.ts
+++ b/modules/client/src/controllers/RequestDepositRightsController.ts
@@ -3,6 +3,7 @@ import { AddressZero, Zero } from "ethers/constants";
 import { bigNumberify, getAddress } from "ethers/utils";
 import tokenAbi from "human-standard-token-abi";
 
+import { CF_METHOD_TIMEOUT } from "../lib/constants";
 import { delayAndThrow, stringify, xpubToAddress } from "../lib/utils";
 import {
   BigNumber,
@@ -210,7 +211,7 @@ export class RequestDepositRightsController extends AbstractController {
           this.log.info(`waiting for proposal acceptance of ${appInstanceId}`);
           this.listener.on(CFCoreTypes.EventName.REJECT_INSTALL, boundReject);
         }),
-        delayAndThrow(90_000, "App install took longer than 15 seconds"),
+        delayAndThrow(CF_METHOD_TIMEOUT, "App install took longer than 15 seconds"),
       ]);
       this.log.info(`App was proposed successfully!: ${appId}`);
       return undefined;

--- a/modules/client/src/controllers/TransferController.ts
+++ b/modules/client/src/controllers/TransferController.ts
@@ -158,7 +158,10 @@ export class TransferController extends AbstractController {
           this.listener.on(CFCoreTypes.EventName.INSTALL_VIRTUAL, boundResolve);
           this.listener.on(CFCoreTypes.EventName.REJECT_INSTALL_VIRTUAL, boundReject);
         }),
-        delayAndThrow(CF_METHOD_TIMEOUT, "App install took longer than 15 seconds"),
+        delayAndThrow(
+          CF_METHOD_TIMEOUT,
+          `App install took longer than ${CF_METHOD_TIMEOUT / 1000} seconds`,
+        ),
       ]);
       this.log.info(`App was installed successfully!: ${stringify(res)}`);
       return res.appInstanceId;

--- a/modules/client/src/controllers/TransferController.ts
+++ b/modules/client/src/controllers/TransferController.ts
@@ -1,6 +1,7 @@
 import { Zero } from "ethers/constants";
 import { BigNumber } from "ethers/utils";
 
+import { CF_METHOD_TIMEOUT } from "../lib/constants";
 import { delayAndThrow, stringify, xpubToAddress } from "../lib/utils";
 import {
   CFCoreChannel,
@@ -157,7 +158,7 @@ export class TransferController extends AbstractController {
           this.listener.on(CFCoreTypes.EventName.INSTALL_VIRTUAL, boundResolve);
           this.listener.on(CFCoreTypes.EventName.REJECT_INSTALL_VIRTUAL, boundReject);
         }),
-        delayAndThrow(15_000, "App install took longer than 15 seconds"),
+        delayAndThrow(CF_METHOD_TIMEOUT, "App install took longer than 15 seconds"),
       ]);
       this.log.info(`App was installed successfully!: ${stringify(res)}`);
       return res.appInstanceId;

--- a/modules/client/src/lib/constants.ts
+++ b/modules/client/src/lib/constants.ts
@@ -1,1 +1,7 @@
 export const CF_PATH = "m/44'/60'/0'/25446";
+
+// always 1 protocol being run, use locking timeout
+export const CF_METHOD_TIMEOUT = 90_000;
+
+// shortest timeout
+export const NATS_TIMEOUT = 15_000;

--- a/modules/client/src/node.ts
+++ b/modules/client/src/node.ts
@@ -4,6 +4,7 @@ import { Transaction } from "ethers/utils";
 import uuid = require("uuid");
 
 import { ChannelRouter } from "./channelRouter";
+import { NATS_TIMEOUT } from "./lib/constants";
 import { Logger } from "./lib/logger";
 import { stringify } from "./lib/utils";
 import {
@@ -24,8 +25,6 @@ import {
 
 // Include our access token when interacting with these subjects
 const guardedSubjects = ["channel", "lock", "transfer"];
-
-const API_TIMEOUT = 100_000;
 
 export interface INodeApiClient {
   acquireLock(lockName: string, callback: (...args: any[]) => any, timeout: number): Promise<any>;
@@ -315,13 +314,13 @@ export class NodeApiClient implements INodeApiClient {
       this.assertAuthToken();
       payload.token = await this.token;
     }
-    let msg = await this.messaging.request(subject, API_TIMEOUT, payload);
+    let msg = await this.messaging.request(subject, NATS_TIMEOUT, payload);
     let error = msg ? (msg.data ? (msg.data.response ? msg.data.response.err : "") : "") : "";
     if (error && error.startsWith("Invalid token")) {
       this.log.info(`Auth error, token might have expired. Let's get a fresh token & try again.`);
       this.token = this.getAuthToken();
       payload.token = await this.token;
-      msg = await this.messaging.request(subject, API_TIMEOUT, payload);
+      msg = await this.messaging.request(subject, NATS_TIMEOUT, payload);
       error = msg ? (msg.data ? (msg.data.response ? msg.data.response.err : "") : "") : "";
     }
     if (!msg.data) {

--- a/modules/contracts/package.json
+++ b/modules/contracts/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@connext/cf-adjudicator-contracts": "0.4.1",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
-    "@connext/cf-types": "1.2.17",
+    "@connext/cf-types": "1.2.18",
     "@types/chai": "4.2.4",
     "chai": "4.2.0",
     "dotenv": "8.2.0",

--- a/modules/contracts/package.json
+++ b/modules/contracts/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@connext/cf-adjudicator-contracts": "0.4.1",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
-    "@connext/cf-types": "1.2.16",
+    "@connext/cf-types": "1.2.17",
     "@types/chai": "4.2.4",
     "chai": "4.2.0",
     "dotenv": "8.2.0",

--- a/modules/daicard/package.json
+++ b/modules/daicard/package.json
@@ -12,8 +12,8 @@
     "format": "prettier --write \"src/**/*.js\""
 	},
 	"dependencies": {
-    "@connext/client": "1.2.16",
-    "@connext/types": "1.2.16",
+    "@connext/client": "1.2.17",
+    "@connext/types": "1.2.17",
 		"@material-ui/core": "4.6.0",
 		"@material-ui/icons": "4.5.1",
 		"@walletconnect/browser": "1.0.0-beta.39",
@@ -40,7 +40,7 @@
   	"xstate": "4.6.7"
 	},
 	"devDependencies": {
-		"@connext/types": "1.2.16",
+		"@connext/types": "1.2.17",
 		"bn.js": "5.0.0",
 		"chai-bn": "0.2.0"
 	},

--- a/modules/daicard/package.json
+++ b/modules/daicard/package.json
@@ -12,8 +12,8 @@
     "format": "prettier --write \"src/**/*.js\""
 	},
 	"dependencies": {
-    "@connext/client": "1.2.17",
-    "@connext/types": "1.2.17",
+    "@connext/client": "1.2.18",
+    "@connext/types": "1.2.18",
 		"@material-ui/core": "4.6.0",
 		"@material-ui/icons": "4.5.1",
 		"@walletconnect/browser": "1.0.0-beta.39",
@@ -40,7 +40,7 @@
   	"xstate": "4.6.7"
 	},
 	"devDependencies": {
-		"@connext/types": "1.2.17",
+		"@connext/types": "1.2.18",
 		"bn.js": "5.0.0",
 		"chai-bn": "0.2.0"
 	},

--- a/modules/dashboard/package.json
+++ b/modules/dashboard/package.json
@@ -9,7 +9,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@connext/messaging": "1.2.17",
+    "@connext/messaging": "1.2.18",
     "@material-ui/core": "4.6.0",
     "@material-ui/icons": "4.5.1",
     "react": "16.11.0",

--- a/modules/dashboard/package.json
+++ b/modules/dashboard/package.json
@@ -9,7 +9,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@connext/messaging": "1.2.16",
+    "@connext/messaging": "1.2.17",
     "@material-ui/core": "4.6.0",
     "@material-ui/icons": "4.5.1",
     "react": "16.11.0",

--- a/modules/messaging/package.json
+++ b/modules/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/messaging",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/index.d.ts",
@@ -14,7 +14,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "@connext/types": "1.2.16",
+    "@connext/types": "1.2.17",
     "ts-nats": "1.2.4",
     "websocket-nats": "0.3.3"
   },

--- a/modules/messaging/package.json
+++ b/modules/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/messaging",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/index.d.ts",
@@ -14,7 +14,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "@connext/types": "1.2.17",
+    "@connext/types": "1.2.18",
     "ts-nats": "1.2.4",
     "websocket-nats": "0.3.3"
   },

--- a/modules/node/package.json
+++ b/modules/node/package.json
@@ -20,9 +20,9 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
-    "@connext/cf-core": "1.2.16",
-    "@connext/messaging": "1.2.16",
-    "@connext/types": "1.2.16",
+    "@connext/cf-core": "1.2.17",
+    "@connext/messaging": "1.2.17",
+    "@connext/types": "1.2.17",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
     "@nestjs/common": "6.5.3",
     "@nestjs/core": "6.5.3",

--- a/modules/node/package.json
+++ b/modules/node/package.json
@@ -20,9 +20,9 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
-    "@connext/cf-core": "1.2.17",
-    "@connext/messaging": "1.2.17",
-    "@connext/types": "1.2.17",
+    "@connext/cf-core": "1.2.18",
+    "@connext/messaging": "1.2.18",
+    "@connext/types": "1.2.18",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
     "@nestjs/common": "6.5.3",
     "@nestjs/core": "6.5.3",

--- a/modules/node/src/constants.ts
+++ b/modules/node/src/constants.ts
@@ -9,7 +9,7 @@ export const CF_PATH = "m/44'/60'/0'/25446";
 // should be 3x the IO_SEND_AND_WAIT_TIMEOUT of cf-core
 // to account for 3 IO_SEND_AND_WAITs by intermediary in
 // the install virtual protocol
-export const LOCK_SERVICE_TTL = 90_0000;
+export const LOCK_SERVICE_TTL = 90_000;
 
 // PROVIDERS
 export const AdminMessagingProviderId = "ADMIN_MESSAGING";

--- a/modules/node/src/constants.ts
+++ b/modules/node/src/constants.ts
@@ -6,6 +6,11 @@ import { PaymentProfile } from "./paymentProfile/paymentProfile.entity";
 // PROTOCOL CONSTANTS
 export const CF_PATH = "m/44'/60'/0'/25446";
 
+// should be 3x the IO_SEND_AND_WAIT_TIMEOUT of cf-core
+// to account for 3 IO_SEND_AND_WAITs by intermediary in
+// the install virtual protocol
+export const LOCK_SERVICE_TTL = 90_0000;
+
 // PROVIDERS
 export const AdminMessagingProviderId = "ADMIN_MESSAGING";
 export const AppRegistryProviderId = "APP_REGISTRY";

--- a/modules/node/src/lock/lock.service.ts
+++ b/modules/node/src/lock/lock.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from "@nestjs/common";
 import Redlock, { Lock } from "redlock";
 
-import { RedlockProviderId } from "../constants";
+import { LOCK_SERVICE_TTL, RedlockProviderId } from "../constants";
 import { CLogger } from "../util";
 
 const logger = new CLogger("LockService");
@@ -15,7 +15,7 @@ export class LockService {
     callback: (...args: any[]) => any,
     timeout: number,
   ): Promise<any> {
-    const hardcodedTTL = 90_000;
+    const hardcodedTTL = LOCK_SERVICE_TTL;
     logger.debug(`Using lock ttl of ${hardcodedTTL / 1000} seconds`);
     logger.debug(`Acquiring lock for ${lockName} ${Date.now()}`);
     return new Promise((resolve: any, reject: any): any => {
@@ -64,8 +64,8 @@ export class LockService {
     });
   }
 
-  async acquireLock(lockName: string, lockTTL: number = 90_000): Promise<string> {
-    const hardcodedTTL = 90_000;
+  async acquireLock(lockName: string, lockTTL: number = LOCK_SERVICE_TTL): Promise<string> {
+    const hardcodedTTL = LOCK_SERVICE_TTL;
     logger.debug(`Using lock ttl of ${hardcodedTTL / 1000} seconds`);
     logger.debug(`Acquiring lock for ${lockName} at ${Date.now()}`);
     return new Promise((resolve: any, reject: any): any => {

--- a/modules/payment-bot/package.json
+++ b/modules/payment-bot/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@connext/client": "1.2.17",
+    "@connext/client": "1.2.18",
     "commander": "4.0.0",
     "dotenv": "8.2.0",
     "ethers": "4.0.39",
@@ -20,7 +20,7 @@
     "uuid": "3.3.3"
   },
   "devDependencies": {
-    "@connext/types": "1.2.17",
+    "@connext/types": "1.2.18",
     "@types/node-fetch": "2.5.3",
     "env-cmd": "10.0.1",
     "ts-node": "8.4.1",

--- a/modules/payment-bot/package.json
+++ b/modules/payment-bot/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@connext/client": "1.2.16",
+    "@connext/client": "1.2.17",
     "commander": "4.0.0",
     "dotenv": "8.2.0",
     "ethers": "4.0.39",
@@ -20,7 +20,7 @@
     "uuid": "3.3.3"
   },
   "devDependencies": {
-    "@connext/types": "1.2.16",
+    "@connext/types": "1.2.17",
     "@types/node-fetch": "2.5.3",
     "env-cmd": "10.0.1",
     "ts-node": "8.4.1",

--- a/modules/types/package.json
+++ b/modules/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/types",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "TypeScript typings for common Connext types",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -14,8 +14,8 @@
     "test": "./node_modules/.bin/jest"
   },
   "dependencies": {
-    "@connext/cf-types": "1.2.16",
-    "@connext/cf-core": "1.2.16",
+    "@connext/cf-types": "1.2.17",
+    "@connext/cf-core": "1.2.17",
     "ethers": "4.0.39"
   },
   "devDependencies": {

--- a/modules/types/package.json
+++ b/modules/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/types",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "TypeScript typings for common Connext types",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -14,8 +14,8 @@
     "test": "./node_modules/.bin/jest"
   },
   "dependencies": {
-    "@connext/cf-types": "1.2.17",
-    "@connext/cf-core": "1.2.17",
+    "@connext/cf-types": "1.2.18",
+    "@connext/cf-core": "1.2.18",
     "ethers": "4.0.39"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@connext/indra",
-	"version": "2.3.7",
+	"version": "2.3.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -37681,8 +37681,9 @@
 							"optional": true,
 							"requires": {
 								"debug": "^2.2.0",
-								"nan": "^2.3.3",
-								"typedarray-to-buffer": "^3.1.2",
+								"es5-ext": "^0.10.50",
+								"nan": "^2.14.0",
+								"typedarray-to-buffer": "^3.1.5",
 								"yaeti": "^0.0.6"
 							}
 						}


### PR DESCRIPTION
## The Problem
Fixes #591 

Current timeouts are a little off.
- redis: 90s (node/src/lock)
    - should be multiples of send and wait
    - protocol with most sends and waits: install-virtual (intermediary has 3
       IO_SEND_AND_WAITs)
- IO_SEND_AND_WAIT: 90s (cf-core/src/node.ts)
    - should be 1/3 redis timeout
- cypress: 180s
    - should be 10x multiple of redis timeout (a test will include max of 10 protocols: setup 1, deposit(propose, install, uninstall), pay(propose, install), setup 2, redeem(propose, install, take action, uninstall))
- client: 15s, 90s for request rights
    - the race condition should be redis timeout * # protocols in race
- nats: 15s
    - should be shortest timeout

## The Solution
Set all timeouts to use constants in the `constants.ts` files of respective packages. New settings:

- redis: 90s (node/src/lock)
- IO_SEND_AND_WAIT: 30s
- cypress: 270s
    - max timeout would be 900s, want to not publish something that takes that long tho
- client: 90s
    - always 1 protocol being run, use redis timeout
- nats: 15s
    - could be shorter

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [x] I am making this PR against staging, not master
- [x] My code follows the code style of this project.
- [x] I have described any backwards-incompatibility implications above.
- [x] I have highlighted which parts of the code should be reviewed most carefully.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
