### PR TITLE
Deposit edgecase hotfix

### DIFF
--- a/modules/cf-adjudicator-contracts/package.json
+++ b/modules/cf-adjudicator-contracts/package.json
@@ -21,7 +21,7 @@
     "solidity"
   ],
   "devDependencies": {
-    "@connext/cf-types": "1.2.14",
+    "@connext/cf-types": "1.2.19",
     "@types/node": "12.12.7",
     "@types/chai": "4.2.4",
     "chai": "4.2.0",

--- a/modules/cf-apps/package.json
+++ b/modules/cf-apps/package.json
@@ -17,7 +17,7 @@
     "lint:ts": "tslint -c tslint.json -p ."
   },
   "devDependencies": {
-    "@connext/cf-types": "1.2.14",
+    "@connext/cf-types": "1.2.19",
     "@connext/cf-adjudicator-contracts": "0.4.1",
     "@types/chai": "4.2.4",
     "@types/mocha": "5.2.7",

--- a/modules/cf-core/package.json
+++ b/modules/cf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/cf-core",
-  "version": "1.2.14",
+  "version": "1.2.19",
   "main": "dist/src/index.js",
   "iife": "dist/src/index.iife.js",
   "types": "dist/src/index.d.ts",
@@ -19,7 +19,7 @@
   "dependencies": {
     "@connext/cf-adjudicator-contracts": "0.4.1",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
-    "@connext/types": "1.2.14",
+    "@connext/types": "1.2.19",
     "@counterfactual/cf-adjudicator-contracts": "0.0.9",
     "@counterfactual/cf-funding-protocol-contracts": "0.0.12",
     "ethers": "4.0.39",

--- a/modules/cf-types/package.json
+++ b/modules/cf-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/cf-types",
-  "version": "1.2.14",
+  "version": "1.2.19",
   "description": "TypeScript typings for common Counterfactual types",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/client",
-  "version": "1.2.14",
+  "version": "1.2.19",
   "description": "Shared code between wallet and node",
   "main": "dist/index.js",
   "files": ["dist", "src", "types"],
@@ -12,10 +12,10 @@
     "test": "./node_modules/.bin/jest"
   },
   "dependencies": {
-    "@connext/cf-core": "1.2.14",
+    "@connext/cf-core": "1.2.19",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
-    "@connext/messaging": "1.2.14",
-    "@connext/types": "1.2.14",
+    "@connext/messaging": "1.2.19",
+    "@connext/types": "1.2.19",
     "core-js": "3.4.0",
     "eth-crypto": "1.5.0",
     "ethers": "4.0.39",

--- a/modules/client/src/connext.ts
+++ b/modules/client/src/connext.ts
@@ -226,6 +226,9 @@ export const connect = async (opts: ClientOptions): Promise<IConnextClient> => {
   log.debug("Registering subscriptions");
   await client.registerSubscriptions();
 
+  // check if there is a coin refund app installed
+  await client.uninstallCoinBalanceIfNeeded();
+
   // make sure there is not an active withdrawal with >= MAX_WITHDRAWAL_RETRIES
   log.debug("Resubmitting active withdrawals");
   await client.resubmitActiveWithdrawal();
@@ -573,6 +576,13 @@ export class ConnextClient implements IConnextClient {
     return this.listener.on(event, callback);
   };
 
+  public once = (
+    event: ConnextEvent | CFCoreTypes.EventName,
+    callback: (...args: any[]) => void,
+  ): ConnextListener => {
+    return this.listener.once(event, callback);
+  };
+
   public emit = (event: ConnextEvent | CFCoreTypes.EventName, data: any): boolean => {
     return this.listener.emit(event, data);
   };
@@ -905,6 +915,84 @@ export class ConnextClient implements IConnextClient {
       bigNumberify(givenTransaction.value).eq(expected.value) &&
       givenTransaction.data === expected.data
     );
+  };
+
+  public uninstallCoinBalanceIfNeeded = async (): Promise<void> => {
+    // check if there is a coin refund app installed
+    const coinRefund = (await this.getAppInstances()).filter(app => {
+      return app.appInterface.addr === this.config.contractAddresses.CoinBalanceRefundApp;
+    })[0];
+    if (!coinRefund) {
+      this.log.debug("No coin balance refund app found");
+      return;
+    }
+
+    this.log.debug(
+      "Installed coin balance refund app found, checking if deposit has been executed",
+    );
+    // if the balance of the multisig is *higher* than the threshold, then a
+    // deposit has been executed.
+    // because only one deposit can be performed at once, assume that
+    // uninstalling will safely add the deposit to the free balance of the
+    // correct channel participant.
+
+    // NOTE: in the case of a transaction being stuck in the mempool due to a
+    // highly clogged chain, your channel will be **locked** because of this
+    // permanently installed application
+
+    const latestState = coinRefund.latestState;
+    const threshold = bigNumberify(latestState["threshold"]);
+    const isClientDeposit = latestState["recipient"] === this.freeBalanceAddress;
+    const isTokenDeposit =
+      latestState["tokenAddress"] && latestState["tokenAddress"] !== AddressZero;
+    const multisigBalance = !isTokenDeposit
+      ? await this.ethProvider.getBalance(this.multisigAddress)
+      : await new Contract(
+          latestState["tokenAddress"],
+          tokenAbi,
+          this.ethProvider,
+        ).functions.balanceOf(this.multisigAddress);
+
+    if (multisigBalance.lt(threshold)) {
+      throw new Error(
+        `Something is wrong! multisig balance is less than the threshold of the installed coin balance refund app.`,
+      );
+    }
+
+    // define helper fn to uninstall coin balance refund
+    const uninstallRefund = async (): Promise<void> => {
+      this.log.debug("Deposit has been executed, uninstalling refund app");
+      // deposit has been executed, uninstall
+      await this.uninstallApp(coinRefund.identityHash);
+      this.log.debug("Successfully uninstalled");
+    };
+
+    // deposit still needs to be executed, wait to uninstall
+    if (multisigBalance.eq(threshold)) {
+      this.log.warn(
+        `Coin balance refund app found installed, but no deposit successfully executed. Leaving app installed and waiting for deposit of ${
+          latestState["tokenAddress"]
+        } from ${isClientDeposit ? `client` : `node`}`,
+      );
+      // if the deposit is from the user, register a listener to wait for
+      // for successful uninstalling since their queued uninstall request
+      // would be lost. if the deposit is from the node, they will be waiting
+      // to send an uninstall request to the client
+      if (isClientDeposit) {
+        if (isTokenDeposit) {
+          new Contract(latestState["tokenAddress"], tokenAbi, this.ethProvider).once(
+            "Transfer",
+            async () => await uninstallRefund(),
+          );
+        } else {
+          this.ethProvider.once(this.multisigAddress, async () => await uninstallRefund());
+        }
+      }
+      return;
+    }
+
+    // multisig bal > threshold so deposit has been executed, uninstall
+    await uninstallRefund();
   };
 
   public resubmitActiveWithdrawal = async (): Promise<void> => {

--- a/modules/contracts/package.json
+++ b/modules/contracts/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@connext/cf-adjudicator-contracts": "0.4.1",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
-    "@connext/cf-types": "1.2.14",
+    "@connext/cf-types": "1.2.19",
     "@types/chai": "4.2.4",
     "chai": "4.2.0",
     "dotenv": "8.2.0",

--- a/modules/daicard/package.json
+++ b/modules/daicard/package.json
@@ -12,8 +12,8 @@
     "format": "prettier --write \"src/**/*.js\""
 	},
 	"dependencies": {
-    "@connext/client": "1.2.14",
-    "@connext/types": "1.2.14",
+    "@connext/client": "1.2.19",
+    "@connext/types": "1.2.19",
 		"@material-ui/core": "4.6.0",
 		"@material-ui/icons": "4.5.1",
 		"@walletconnect/browser": "1.0.0-beta.39",
@@ -40,7 +40,7 @@
   	"xstate": "4.6.7"
 	},
 	"devDependencies": {
-		"@connext/types": "1.2.14",
+		"@connext/types": "1.2.19",
 		"bn.js": "5.0.0",
 		"chai-bn": "0.2.0"
 	},

--- a/modules/dashboard/package.json
+++ b/modules/dashboard/package.json
@@ -9,7 +9,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@connext/messaging": "1.2.14",
+    "@connext/messaging": "1.2.19",
     "@material-ui/core": "4.6.0",
     "@material-ui/icons": "4.5.1",
     "react": "16.11.0",

--- a/modules/messaging/package.json
+++ b/modules/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/messaging",
-  "version": "1.2.14",
+  "version": "1.2.19",
   "main": "dist/index.js",
   "iife": "dist/index.iife.js",
   "types": "dist/index.d.ts",
@@ -14,7 +14,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "@connext/types": "1.2.14",
+    "@connext/types": "1.2.19",
     "ts-nats": "1.2.4",
     "websocket-nats": "0.3.3"
   },

--- a/modules/node/package.json
+++ b/modules/node/package.json
@@ -20,9 +20,9 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
-    "@connext/cf-core": "1.2.14",
-    "@connext/messaging": "1.2.14",
-    "@connext/types": "1.2.14",
+    "@connext/cf-core": "1.2.19",
+    "@connext/messaging": "1.2.19",
+    "@connext/types": "1.2.19",
     "@connext/cf-funding-protocol-contracts": "0.4.1",
     "@nestjs/common": "6.5.3",
     "@nestjs/core": "6.5.3",

--- a/modules/payment-bot/package.json
+++ b/modules/payment-bot/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@connext/client": "1.2.14",
+    "@connext/client": "1.2.19",
     "commander": "4.0.0",
     "dotenv": "8.2.0",
     "ethers": "4.0.39",
@@ -19,7 +19,7 @@
     "uuid": "3.3.3"
   },
   "devDependencies": {
-    "@connext/types": "1.2.14",
+    "@connext/types": "1.2.19",
     "@types/node-fetch": "2.5.3",
     "env-cmd": "10.0.1",
     "ts-node": "8.4.1",

--- a/modules/types/package.json
+++ b/modules/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@connext/types",
-  "version": "1.2.14",
+  "version": "1.2.19",
   "description": "TypeScript typings for common Connext types",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -14,8 +14,8 @@
     "test": "./node_modules/.bin/jest"
   },
   "dependencies": {
-    "@connext/cf-types": "1.2.14",
-    "@connext/cf-core": "1.2.14",
+    "@connext/cf-types": "1.2.19",
+    "@connext/cf-core": "1.2.19",
     "ethers": "4.0.39"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@connext/indra",
-	"version": "2.3.7",
+	"version": "2.3.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
## The Problem
If the user goes offline during any deposit (ie with the `CoinBalanceRefund` app installed) there's going to be problems for any future deposits until it's uninstalled.

## The Solution
- Uninstall the `CoinBalanceRefund` app if the multisig balance is above the threshold
- Add a listener if a client's deposit is still in progress to uninstall the app once it gets to the multisig

*Important to note*:
If the chain is clogged, you will not be able to add funds to your channel and you will not be able to receive additional collateral. This is okay, because the risk exists either way, and this still represents a strict improvement over what exists in master (ie you will be trying to add the funds to your free balance once it makes it there regardless, instead of needing manual multisig fund recovery intervention).

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I am making this PR against staging, not master
- [x] My code follows the code style of this project.
- [x] I have described any backwards-incompatibility implications above.
- [x] I have highlighted which parts of the code should be reviewed most carefully.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
Hot fix, making PR against master to not rope in any staging changes