### PR TITLE
630 registry app cleanup

### DIFF
--- a/modules/client/src/connext.ts
+++ b/modules/client/src/connext.ts
@@ -1,5 +1,5 @@
 import { IMessagingService, MessagingServiceFactory } from "@connext/messaging";
-import { CF_PATH, LinkedTransferToRecipientParameters } from "@connext/types";
+import { CF_PATH, LinkedTransferToRecipientParameters, AppInstanceProposal } from "@connext/types";
 import "core-js/stable";
 import EthCrypto from "eth-crypto";
 import { Contract, providers } from "ethers";
@@ -50,7 +50,6 @@ import {
   PaymentProfile,
   RequestCollateralResponse,
   RequestDepositRightsParameters,
-  RequestDepositRightsResponse,
   RescindDepositRightsParameters,
   RescindDepositRightsResponse,
   ResolveConditionParameters,
@@ -236,6 +235,9 @@ export const connect = async (opts: ClientOptions): Promise<IConnextClient> => {
   // check if there is a coin refund app installed for eth and tokens
   await client.uninstallCoinBalanceIfNeeded(AddressZero);
   await client.uninstallCoinBalanceIfNeeded(config.contractAddresses.Token);
+
+  // cleanup any hanging registry apps
+  await client.cleanupRegistryApps();
 
   // make sure there is not an active withdrawal with >= MAX_WITHDRAWAL_RETRIES
   log.debug("Resubmitting active withdrawals");
@@ -977,6 +979,67 @@ export class ConnextClient implements IConnextClient {
       bigNumberify(givenTransaction.value).eq(expected.value) &&
       givenTransaction.data === expected.data
     );
+  };
+
+  /**
+   * NOTE: this function should *only* be called on `connect()`, and is
+   * designed to cleanup channel state in the event of the client going
+   * offline and not completing protocols.
+   *
+   * This function will *only* handle registered applications, or applications
+   * who's desired functionality is well understood. The apps will be handled
+   * as follows:
+   * - proposed swaps: install will be rejected, removing them from the proposed
+   *   app instances and preventing stale swaps from being installed.
+   * - installed swaps: will be automatically uninstalled, thereby executing the
+   *   swap as soon as the client is able.
+   * - proposed linked transfer apps: reject install
+   * - installed linked transfer: leave installed for the hub to uninstall
+   */
+  public cleanupRegistryApps = async (): Promise<void> => {
+    const swapAppRegistryInfo = this.appRegistry.filter(
+      (app: DefaultApp) => app.name === "SimpleTwoPartySwapApp",
+    )[0];
+    const linkedRegistryInfo = this.appRegistry.filter(
+      (app: DefaultApp) => app.name === "SimpleLinkedTransferApp",
+    )[0];
+
+    await this.removeHangingProposalsByDefinition([
+      swapAppRegistryInfo.appDefinitionAddress,
+      linkedRegistryInfo.appDefinitionAddress,
+    ]);
+
+    // deal with any swap apps that are installed
+    await this.uninstallAllAppsByDefintion([swapAppRegistryInfo.appDefinitionAddress]);
+  };
+
+  /**
+   * Removes all proposals of a give app definition type
+   */
+  public removeHangingProposalsByDefinition = async (appDefinitions: string[]): Promise<void> => {
+    // first get all proposed apps
+    const { appInstances: proposed } = await this.getProposedAppInstances();
+
+    // deal with any proposed swap or linked transfer apps
+    const hangingProposals = proposed.filter((proposal: AppInstanceProposal) =>
+      appDefinitions.includes(proposal.appDefinition),
+    );
+    // remove from `proposedAppInstances`
+    for (const hanging of hangingProposals) {
+      await this.rejectInstallApp(hanging.identityHash);
+    }
+  };
+
+  /**
+   * Removes all apps of a given app definition type
+   */
+  public uninstallAllAppsByDefintion = async (appDefinitions: string[]): Promise<void> => {
+    const apps = (await this.getAppInstances()).filter((app: AppInstanceJson) =>
+      appDefinitions.includes(app.appInterface.addr),
+    );
+    for (const app of apps) {
+      await this.uninstallApp(app.identityHash);
+    }
   };
 
   public uninstallCoinBalanceIfNeeded = async (assetId: string = AddressZero): Promise<void> => {

--- a/modules/payment-bot/src/channel.ts
+++ b/modules/payment-bot/src/channel.ts
@@ -1,5 +1,5 @@
 import * as connext from "@connext/client";
-import { CFCoreTypes, ClientOptions, IConnextClient, makeChecksum } from "@connext/types";
+import { ClientOptions, IConnextClient, makeChecksum } from "@connext/types";
 import { AddressZero } from "ethers/constants";
 import { parseEther } from "ethers/utils";
 


### PR DESCRIPTION
## The Problem
Fixes #630 

Apps build up in state and are not cleaned up in the case of client going offline unexpectedly.

## The Solution
On `connect`:
- remove all proposed registered apps from state
- automatically uninstall all swap apps

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [x] I am making this PR against staging, not master
- [x] My code follows the code style of this project.
- [x] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
