### PR TITLE
701 restore state test

### DIFF
--- a/modules/test-runner/src/restoreState/restoreState.test.ts
+++ b/modules/test-runner/src/restoreState/restoreState.test.ts
@@ -35,14 +35,14 @@ describe("Restore State", () => {
     expect(freeBalanceTokenPre[clientA.freeBalanceAddress]).toBe(undefined);
     expect(freeBalanceTokenPre[nodeFreeBalanceAddress]).toBe(undefined);
 
-    // clientA.restoreState();
+    await clientA.restoreState();
 
     // // check balances post
-    // const freeBalanceEthPost = clientA.getFreeBalance(AddressZero);
-    // const freeBalanceTokenPost = clientA.getFreeBalance(tokenAddress);
-    // expect(freeBalanceEthPost[clientA.freeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
-    // expect(freeBalanceEthPost[nodeFreeBalanceAddress]).toBeBigNumberEq(Zero);
-    // expect(freeBalanceTokenPost[clientA.freeBalanceAddress]).toBeBigNumberEq(Zero);
-    // expect(freeBalanceTokenPost[nodeFreeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
+    const freeBalanceEthPost = clientA.getFreeBalance(AddressZero);
+    const freeBalanceTokenPost = clientA.getFreeBalance(tokenAddress);
+    expect(freeBalanceEthPost[clientA.freeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
+    expect(freeBalanceEthPost[nodeFreeBalanceAddress]).toBeBigNumberEq(Zero);
+    expect(freeBalanceTokenPost[clientA.freeBalanceAddress]).toBeBigNumberEq(Zero);
+    expect(freeBalanceTokenPost[nodeFreeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
   });
 });

--- a/modules/test-runner/src/restoreState/restoreState.test.ts
+++ b/modules/test-runner/src/restoreState/restoreState.test.ts
@@ -1,0 +1,40 @@
+import { createClient } from "../util/client";
+import { IConnextClient } from "@connext/types";
+import { xkeyKthAddress } from "@connext/cf-core";
+import { parseEther } from "ethers/utils";
+import { AddressZero, Zero } from "ethers/constants";
+
+describe("Restore State", () => {
+  let clientA: IConnextClient;
+  let tokenAddress: string;
+  let nodeFreeBalanceAddress: string;
+  let nodePublicIdentifier: string;
+
+  beforeEach(async () => {
+    clientA = await createClient();
+
+    tokenAddress = clientA.config.contractAddresses.Token;
+    nodePublicIdentifier = clientA.config.nodePublicIdentifier;
+    nodeFreeBalanceAddress = xkeyKthAddress(nodePublicIdentifier);
+  }, 90_000);
+
+  test("happy case: client can delete its store and restore from a remote backup", async () => {
+    // client deposit and request node collateral
+    await clientA.deposit({ amount: parseEther("0.01").toString(), assetId: AddressZero });
+    await clientA.requestCollateral(tokenAddress);
+
+    // delete store
+
+    // check balances pre (will this work?)
+
+    clientA.restoreState();
+
+    // check balances post
+    const freeBalanceEthPost = clientA.getFreeBalance(AddressZero);
+    const freeBalanceTokenPost = clientA.getFreeBalance(tokenAddress);
+    expect(freeBalanceEthPost[clientA.freeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
+    expect(freeBalanceEthPost[nodeFreeBalanceAddress]).toBeBigNumberEq(Zero);
+    expect(freeBalanceTokenPost[clientA.freeBalanceAddress]).toBeBigNumberEq(Zero);
+    expect(freeBalanceTokenPost[nodeFreeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
+  });
+});

--- a/modules/test-runner/src/restoreState/restoreState.test.ts
+++ b/modules/test-runner/src/restoreState/restoreState.test.ts
@@ -1,4 +1,4 @@
-import { createClient } from "../util/client";
+import { createClient, getStore } from "../util/client";
 import { IConnextClient } from "@connext/types";
 import { xkeyKthAddress } from "@connext/cf-core";
 import { parseEther } from "ethers/utils";
@@ -24,17 +24,25 @@ describe("Restore State", () => {
     await clientA.requestCollateral(tokenAddress);
 
     // delete store
+    const store = getStore();
+    store.reset();
 
     // check balances pre (will this work?)
+    const freeBalanceEthPre = clientA.getFreeBalance(AddressZero);
+    const freeBalanceTokenPre = clientA.getFreeBalance(tokenAddress);
+    expect(freeBalanceEthPre[nodeFreeBalanceAddress]).toBe(undefined);
+    expect(freeBalanceEthPre[nodeFreeBalanceAddress]).toBe(undefined);
+    expect(freeBalanceTokenPre[clientA.freeBalanceAddress]).toBe(undefined);
+    expect(freeBalanceTokenPre[nodeFreeBalanceAddress]).toBe(undefined);
 
-    clientA.restoreState();
+    // clientA.restoreState();
 
-    // check balances post
-    const freeBalanceEthPost = clientA.getFreeBalance(AddressZero);
-    const freeBalanceTokenPost = clientA.getFreeBalance(tokenAddress);
-    expect(freeBalanceEthPost[clientA.freeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
-    expect(freeBalanceEthPost[nodeFreeBalanceAddress]).toBeBigNumberEq(Zero);
-    expect(freeBalanceTokenPost[clientA.freeBalanceAddress]).toBeBigNumberEq(Zero);
-    expect(freeBalanceTokenPost[nodeFreeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
+    // // check balances post
+    // const freeBalanceEthPost = clientA.getFreeBalance(AddressZero);
+    // const freeBalanceTokenPost = clientA.getFreeBalance(tokenAddress);
+    // expect(freeBalanceEthPost[clientA.freeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
+    // expect(freeBalanceEthPost[nodeFreeBalanceAddress]).toBeBigNumberEq(Zero);
+    // expect(freeBalanceTokenPost[clientA.freeBalanceAddress]).toBeBigNumberEq(Zero);
+    // expect(freeBalanceTokenPost[nodeFreeBalanceAddress]).toBeBigNumberEq(parseEther("0.01"));
   });
 });

--- a/modules/test-runner/src/util/client.ts
+++ b/modules/test-runner/src/util/client.ts
@@ -7,16 +7,18 @@ import tokenAbi from "human-standard-token-abi";
 
 import { env } from "./env";
 import { ethProvider } from "./ethprovider";
-import { MemoryStoreServiceFactory } from "./store";
+import { MemoryStoreServiceFactory, MemoryStoreService } from "./store";
 
 const wallet = Wallet.fromMnemonic(env.mnemonic).connect(ethProvider);
+
+let clientStore: MemoryStoreService;
 
 export const createClient = async (
   mnemonic: string = Wallet.createRandom().mnemonic,
 ): Promise<IConnextClient> => {
   const storeServiceFactory = new MemoryStoreServiceFactory();
 
-  const clientStore = storeServiceFactory.createStoreService();
+  clientStore = storeServiceFactory.createStoreService();
   const clientOpts: ClientOptions = {
     ethProviderUrl: env.ethProviderUrl,
     logLevel: env.logLevel,
@@ -43,4 +45,8 @@ export const createClient = async (
   expect(client.publicIdentifier).toBeTruthy();
 
   return client;
+};
+
+export const getStore = (): MemoryStoreService => {
+  return clientStore;
 };


### PR DESCRIPTION
Issue: #701 

Currently failing with the following error:

```  ● Restore State › happy case: client can delete its store and restore from a remote backup

    Call to getStateChannel failed when searching for multisig address: 0x38F0A24FcBC65E06327A292f0F317BB943C94819. This probably means that the StateChannel does not exist yet.

       97 | 
       98 |     if (!stateChannelJson) {
    >  99 |       throw Error(NO_STATE_CHANNEL_FOR_MULTISIG_ADDR(multisigAddress));
          |             ^
      100 |     }
      101 | 
      102 |     const channel = StateChannel.fromJson(stateChannelJson);

      at Store.getStateChannel (../cf-core/src/store.ts:99:13)
```

(only happens when calling `await client.restoreState()`)