### PR TITLE
[daicard, node, client] 571 collateralization issues

### DIFF
--- a/modules/client/src/connext.ts
+++ b/modules/client/src/connext.ts
@@ -259,10 +259,6 @@ export class ConnextClient implements IConnextClient {
     return await this.node.unsubscribeFromSwapRates(from, to);
   };
 
-  public addPaymentProfile = async (profile: PaymentProfile): Promise<PaymentProfile> => {
-    return await this.node.addPaymentProfile(profile);
-  };
-
   public getPaymentProfile = async (assetId?: string): Promise<PaymentProfile | undefined> => {
     return await this.node.getPaymentProfile(assetId);
   };

--- a/modules/client/src/node.ts
+++ b/modules/client/src/node.ts
@@ -28,7 +28,6 @@ const sendFailed = "Failed to send message";
 
 export interface INodeApiClient {
   acquireLock(lockName: string, callback: (...args: any[]) => any, timeout: number): Promise<any>;
-  addPaymentProfile(profile: PaymentProfile): Promise<PaymentProfile>;
   appRegistry(appDetails?: {
     name: SupportedApplication;
     network: SupportedNetwork;
@@ -203,10 +202,6 @@ export class NodeApiClient implements INodeApiClient {
       meta,
       paymentId,
     });
-  }
-
-  public async addPaymentProfile(profile: PaymentProfile): Promise<PaymentProfile> {
-    return await this.send(`channel.add-profile.${this.userPublicIdentifier}`, profile);
   }
 
   public async getPaymentProfile(assetId?: string): Promise<PaymentProfile> {

--- a/modules/client/src/testing/mocks.ts
+++ b/modules/client/src/testing/mocks.ts
@@ -107,7 +107,6 @@ export class MockNodeClientApi implements INodeApiClient {
   // should have keys same as the message passed in to fake messaging client
   // TODO: how well will this work with dynamic paths?
   public static returnValues: any = {
-    addPaymentProfile: {} as PaymentProfile,
     appRegistry: {} as AppRegistry,
     config: {
       chainId: "mocks", // network that your channel is on
@@ -177,10 +176,6 @@ export class MockNodeClientApi implements INodeApiClient {
     return {
       multisigAddress: address,
     };
-  }
-
-  public async addPaymentProfile(): Promise<any> {
-    return MockNodeClientApi.returnValues.addPaymentProfile;
   }
 
   public async getPaymentProfile(): Promise<PaymentProfile | undefined> {

--- a/modules/node/src/auth/auth.service.ts
+++ b/modules/node/src/auth/auth.service.ts
@@ -110,7 +110,7 @@ export class AuthService {
   verifySig(xpubAddress: string, data: { token: string }): { err: string } | undefined {
     // Get & validate the nonce + signature from provided token
     if (!data || !data.token || data.token.indexOf(":") === -1) {
-      return badToken(`Missing or malformed token in data: ${data || data.token}`);
+      return badToken(`Missing or malformed token in data: ${JSON.stringify(data || data.token)}`);
     }
     const token = data.token;
     const nonce = token.split(":")[0];

--- a/modules/node/src/channel/channel.provider.ts
+++ b/modules/node/src/channel/channel.provider.ts
@@ -165,7 +165,7 @@ class ChannelMessaging extends AbstractMessagingProvider {
     );
     await super.connectRequestReponse(
       "channel.add-profile.>",
-      this.authService.useVerifiedPublicIdentifier(this.addPaymentProfile.bind(this)),
+      this.authService.useAdminToken(this.addPaymentProfile.bind(this)),
     );
     await super.connectRequestReponse(
       "channel.get-profile.>",

--- a/modules/types/src/client.ts
+++ b/modules/types/src/client.ts
@@ -115,7 +115,6 @@ export interface IConnextClient {
   getLatestSwapRate(from: string, to: string): Promise<string>;
   unsubscribeToSwapRates(from: string, to: string): Promise<void>;
   requestCollateral(tokenAddress: string): Promise<RequestCollateralResponse | void>;
-  addPaymentProfile(profile: PaymentProfile): Promise<PaymentProfile>;
   getPaymentProfile(assetId?: string): Promise<PaymentProfile | undefined>;
   getTransferHistory(): Promise<Transfer[]>;
   reclaimPendingAsyncTransfers(): Promise<void>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "indra",
-	"version": "2.3.22",
+	"version": "2.3.23",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
## The Problem

Fixes #571 

Additionally, found a few other things:
- `addPaymentProfile` was in the client API, meaning users could arbitrarily add their own profiles that would be honored when making a `requestCollateral` call (should be an admin function)
- `autoswap` was being called twice, one right after the other at the end of `autoDeposit` and at the next line in the poller
- `autoswap` was also not able to handle edge case where it has insufficient collateral to swap their entire eth balance (but will not add additional collateral following their profile)

## The Solution

- 🔴  BREAKING CHANGE!! 🔴  `addPaymentProfile` removed from client API and modified to use admin auth 
- `autoswap` function cleaned up

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [x] I am making this PR against staging, not master
- [x] My code follows the code style of this project.
- [x] I have described any backwards-incompatibility implications above.
- [x] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
