### PR TITLE
Expose removeListener in client api

### DIFF
--- a/modules/client/src/connext.ts
+++ b/modules/client/src/connext.ts
@@ -462,6 +462,10 @@ export class ConnextClient implements IConnextClient {
     return this.listener.emit(event, data);
   };
 
+  public removeListener = (event: ConnextEvent, callback: (...args: any[]) => void): ConnextListener => {
+    return this.listener.removeListener(event, callback);
+  };
+
   ///////////////////////////////////
   // PROVIDER/ROUTER METHODS
 

--- a/modules/types/src/client.ts
+++ b/modules/types/src/client.ts
@@ -82,6 +82,7 @@ export interface IConnextClient {
   on(event: ConnextEvent | CFCoreTypes.RpcMethodName, callback: (...args: any[]) => void): void;
   once(event: ConnextEvent | CFCoreTypes.RpcMethodName, callback: (...args: any[]) => void): void;
   emit(event: ConnextEvent | CFCoreTypes.RpcMethodName, data: any): boolean;
+  removeListener(event: ConnextEvent | CFCoreTypes.RpcMethodName, callback: (...args: any[]) => void): void;
 
   ///////////////////////////////////
   // CORE CHANNEL METHODS


### PR DESCRIPTION
## The Problem
I find myself need to add temporary listeners and then remove them and it would be cleaner not to have to access then inner `listener` object

## The Solution
expose removeListener api

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [x] I am making this PR against staging, not master
- [x] My code follows the code style of this project.
- [x] I have described any backwards-incompatibility implications above.
- [x] I have highlighted which parts of the code should be reviewed most carefully.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
