### PR TITLE
[client] If pending async transfers fail, don't block client startup

### DIFF
--- a/modules/client/src/connect.ts
+++ b/modules/client/src/connect.ts
@@ -276,7 +276,13 @@ export const connect = async (
   // no need to await this if it needs collateral
   // TODO: without await causes race conditions in bot, refactor to
   // use events
-  await client.reclaimPendingAsyncTransfers();
+  try {
+    await client.reclaimPendingAsyncTransfers();
+  } catch (e) {
+    log.error(
+      `Could not reclaim pending async transfers: ${e}... will attempt again on next connection`,
+    );
+  }
 
   // check in with node to do remaining work
   await client.clientCheckIn();


### PR DESCRIPTION
<!--- Make sure your title is descriptive -->
<!--- If you have any questions, don't hesitate to reach out to us on Discord! -->

## The Problem
#858 

## The Solution
<!--- Describe the changes you made in detail -->
<!--- Describe any backwards-incompatible changes you might have introduced -->
<!--- Which parts of this PR should be given extra attention during review -->
<!--- Leave comments on important parts of the source diff to clarify above prompts -->
Add try-catch around reclaim async payments function in `connect()` if an error is thrown while reclaiming transfers, allow the rest of the `connect` process to start up.

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [x] I am making this PR against staging, not master
- [x] My code follows the code style of this project.
- [x] I have described any backwards-incompatibility implications above.
- [x] I have highlighted which parts of the code should be reviewed most carefully.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
