### PR TITLE
Signing Refactor - Hashing and Signature parsing improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,12 +293,12 @@ ws-tcp-relay: ops/ws-tcp-relay.dockerfile
 ########################################
 # JS & bundles
 
-client: cf-core contracts types apps crypto messaging store channel-provider $(shell find $(client)/src $(client)/tsconfig.json $(find_options))
+client: cf-core types contracts apps messaging channel-provider $(shell find $(client)/src $(client)/tsconfig.json $(find_options))
 	$(log_start)
 	$(docker_run) "cd modules/client && npm run build"
 	$(log_finish) && mv -f $(totalTime) $(flags)/$@
 
-cf-core: node-modules types contracts store $(shell find $(cf-core)/src $(cf-core)/test $(cf-core)/tsconfig.json $(find_options))
+cf-core: node-modules types contracts crypto store $(shell find $(cf-core)/src $(cf-core)/test $(cf-core)/tsconfig.json $(find_options))
 	$(log_start)
 	$(docker_run) "cd modules/cf-core && npm run build"
 	$(log_finish) && mv -f $(totalTime) $(flags)/$@
@@ -328,7 +328,7 @@ messaging: node-modules types $(shell find $(messaging)/src $(find_options))
 	$(docker_run) "cd modules/messaging && npm run build"
 	$(log_finish) && mv -f $(totalTime) $(flags)/$@
 
-node: cf-core contracts types apps messaging $(shell find $(node)/src $(node)/migrations $(find_options))
+node: cf-core types contracts crypto apps messaging $(shell find $(node)/src $(node)/migrations $(find_options))
 	$(log_start)
 	$(docker_run) "cd modules/node && npm run build && touch src/main.ts"
 	$(log_finish) && mv -f $(totalTime) $(flags)/$@
@@ -348,7 +348,7 @@ types: node-modules $(shell find $(types)/src $(find_options))
 	$(docker_run) "cd modules/types && npm run build"
 	$(log_finish) && mv -f $(totalTime) $(flags)/$@
 
-apps: node-modules cf-core types $(shell find $(apps)/src $(find_options))
+apps: node-modules types crypto cf-core $(shell find $(apps)/src $(find_options))
 	$(log_start)
 	$(docker_run) "cd modules/apps && npm run build"
 	$(log_finish) && mv -f $(totalTime) $(flags)/$@
@@ -356,7 +356,7 @@ apps: node-modules cf-core types $(shell find $(apps)/src $(find_options))
 ########################################
 # Common Prerequisites
 
-contracts: node-modules contract-artifacts types $(shell find $(contracts)/index.ts $(contracts)/test $(contracts)/tsconfig.json $(find_options))
+contracts: node-modules types contract-artifacts $(shell find $(contracts)/index.ts $(contracts)/test $(contracts)/tsconfig.json $(find_options))
 	$(log_start)
 	$(docker_run) "cd modules/contracts && npm run transpile"
 	$(log_finish) && mv -f $(totalTime) $(flags)/$@

--- a/modules/apps/package.json
+++ b/modules/apps/package.json
@@ -6,7 +6,10 @@
   "module": "dist/index.esm.js",
   "types": "dist/src/index.d.ts",
   "iife": "dist/index-iife.js",
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "build": "./node_modules/.bin/tsc -b . && ./node_modules/.bin/rollup -c",
     "lint": "../../node_modules/.bin/eslint -c '../../.eslintrc.js' --fix 'src/**/*'",
@@ -17,6 +20,7 @@
   "devDependencies": {
     "@connext/cf-core": "6.0.0-alpha.0",
     "@connext/contracts": "1.0.5",
+    "@connext/crypto": "6.0.0-alpha.0",
     "@connext/types": "6.0.0-alpha.0",
     "ethers": "4.0.45",
     "rollup": "1.31.1",

--- a/modules/apps/src/WithdrawApp/validation.ts
+++ b/modules/apps/src/WithdrawApp/validation.ts
@@ -1,5 +1,10 @@
 import { xkeyKthAddress } from "@connext/cf-core";
-import { CFCoreTypes, CoinTransferBigNumber, bigNumberifyObj, WithdrawAppState } from "@connext/types";
+import {
+  CFCoreTypes,
+  CoinTransferBigNumber,
+  bigNumberifyObj,
+  WithdrawAppState,
+} from "@connext/types";
 
 import { unidirectionalCoinTransferValidation } from "../shared";
 import { convertWithrawAppState } from "./convert";
@@ -18,7 +23,10 @@ export const validateWithdrawApp = (
   const initiatorFreeBalanceAddress = xkeyKthAddress(initiatorPublicIdentifier);
   const responderFreeBalanceAddress = xkeyKthAddress(responderPublicIdentifier);
 
-  const initialState: WithdrawAppState<BigNumber> = convertWithrawAppState("bignumber", initialStateBadType);
+  const initialState: WithdrawAppState<BigNumber> = convertWithrawAppState(
+    "bignumber",
+    initialStateBadType,
+  );
 
   initialState.transfers = initialState.transfers.map((transfer: CoinTransferBigNumber) =>
     bigNumberifyObj(transfer),
@@ -34,36 +42,37 @@ export const validateWithdrawApp = (
     responderTransfer,
   );
 
-  if(initialState.finalized) {
+  if (initialState.finalized) {
+    throw new Error(`Cannot install a withdraw app with a finalized state. State: ${initialState}`);
+  }
+
+  if (initialState.signatures[1] != HashZero) {
     throw new Error(
-        `Cannot install a withdraw app with a finalized state. State: ${initialState}`,
-      );
+      `Cannot install a withdraw app with a populated signatures[1] field. Signatures[1]: ${initialState.signatures[1]}`,,
+    );;
   }
 
-  if(initialState.signatures[1] != HashZero) {
-      throw new Error(
-        `Cannot install a withdraw app with a populated signatures[1] field. Signatures[1]: ${initialState.signatures[1]}`
-      )
+  if (
+    initialState.signers[0] != initiatorFreeBalanceAddress ||
+    initialState.signers[1] != responderFreeBalanceAddress
+  ) {
+    throw new Error(
+      `Cannot install a withdraw app if signers[] do not match multisig participant addresses. Signers[]: ${initialState.signers}`,,
+    );;
   }
 
-  if(initialState.signers[0] != initiatorFreeBalanceAddress || initialState.signers[1] != responderFreeBalanceAddress) {
-      throw new Error(
-        `Cannot install a withdraw app if signers[] do not match multisig participant addresses. Signers[]: ${initialState.signers}`
-      )
+  if (!initialState.transfers[1].amount.eq(Zero)) {
+    throw new Error(
+      `Cannot install a withdraw app with nonzero recipient amount. ${initialState.transfers[1].amount.toString()}`,,
+    );;
   }
 
-  if(!initialState.transfers[1].amount.eq(Zero)) {
-      throw new Error(
-        `Cannot install a withdraw app with nonzero recipient amount. ${initialState.transfers[1].amount.toString()}`
-      )
-  }
+  let recovered = recoverAddress(initialState.data, initialState.signatures[0]);
 
-  let recovered = recoverAddress(initialState.data, initialState.signatures[0])
-
-  if(recovered != initialState.signers[0]) {
-      throw new Error(
-        `Cannot install withdraw app - incorrect signer recovered from initiator sig on data. 
-         Recovered: ${recovered}, Expected: ${initialState.signers[0]}`
-      )
+  if (recovered != initialState.signers[0]) {
+    throw new Error(
+      `Cannot install withdraw app - incorrect signer recovered from initiator sig on data. 
+         Recovered: ${recovered}, Expected: ${initialState.signers[0]}`,
+    );;
   }
 };

--- a/modules/apps/src/WithdrawApp/validation.ts
+++ b/modules/apps/src/WithdrawApp/validation.ts
@@ -48,8 +48,8 @@ export const validateWithdrawApp = (
 
   if (initialState.signatures[1] != HashZero) {
     throw new Error(
-      `Cannot install a withdraw app with a populated signatures[1] field. Signatures[1]: ${initialState.signatures[1]}`,,
-    );;
+      `Cannot install a withdraw app with a populated signatures[1] field. Signatures[1]: ${initialState.signatures[1]}`,
+    );
   }
 
   if (
@@ -57,14 +57,14 @@ export const validateWithdrawApp = (
     initialState.signers[1] != responderFreeBalanceAddress
   ) {
     throw new Error(
-      `Cannot install a withdraw app if signers[] do not match multisig participant addresses. Signers[]: ${initialState.signers}`,,
-    );;
+      `Cannot install a withdraw app if signers[] do not match multisig participant addresses. Signers[]: ${initialState.signers}`,
+    );
   }
 
   if (!initialState.transfers[1].amount.eq(Zero)) {
     throw new Error(
-      `Cannot install a withdraw app with nonzero recipient amount. ${initialState.transfers[1].amount.toString()}`,,
-    );;
+      `Cannot install a withdraw app with nonzero recipient amount. ${initialState.transfers[1].amount.toString()}`,
+    );
   }
 
   let recovered = recoverAddress(initialState.data, initialState.signatures[0]);
@@ -73,6 +73,6 @@ export const validateWithdrawApp = (
     throw new Error(
       `Cannot install withdraw app - incorrect signer recovered from initiator sig on data. 
          Recovered: ${recovered}, Expected: ${initialState.signers[0]}`,
-    );;
+    );
   }
 };

--- a/modules/cf-core/package.json
+++ b/modules/cf-core/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@connext/contracts": "1.0.5",
+    "@connext/crypto": "6.0.0-alpha.0",
     "@connext/types": "6.0.0-alpha.0",
     "ethers": "4.0.45",
     "@openzeppelin/contracts": "2.5.0",

--- a/modules/cf-core/src/ethereum/conditional-transaction-commitment.ts
+++ b/modules/cf-core/src/ethereum/conditional-transaction-commitment.ts
@@ -23,7 +23,7 @@ export class ConditionalTransactionCommitment extends MultisigCommitment {
     public readonly freeBalanceAppIdentityHash: string,
     public readonly interpreterAddr: string,
     public readonly interpreterParams: string,
-    participantSignatures: Signature[] = [],
+    participantSignatures: string[] = [],
   ) {
     super(multisig, multisigOwners, participantSignatures);
   }

--- a/modules/cf-core/src/ethereum/multisig-commitment.ts
+++ b/modules/cf-core/src/ethereum/multisig-commitment.ts
@@ -58,14 +58,16 @@ export abstract class MultisigCommitment implements EthereumCommitment {
     return { to: this.multisigAddress, value: 0, data: txData };
   }
 
-  public hashToSign(): string {
+  public encode(): string {
     const { to, value, data, operation } = this.getTransactionDetails();
-    return keccak256(
-      solidityPack(
-        ["bytes1", "address[]", "address", "uint256", "bytes", "uint8"],
-        ["0x19", this.multisigOwners, to, value, data, operation],
-      ),
+    return solidityPack(
+      ["bytes1", "address[]", "address", "uint256", "bytes", "uint8"],
+      ["0x19", this.multisigOwners, to, value, data, operation],
     );
+  }
+
+  public hashToSign(): string {
+    return keccak256(this.encode());
   }
 
   private assertSignatures() {

--- a/modules/cf-core/src/ethereum/multisig-commitment.ts
+++ b/modules/cf-core/src/ethereum/multisig-commitment.ts
@@ -43,9 +43,8 @@ export abstract class MultisigCommitment implements EthereumCommitment {
   public getSignedTransaction(): CFCoreTypes.MinimalTransaction {
     this.assertSignatures();
     const multisigInput = this.getTransactionDetails();
-    const signaturesList = sortSignaturesBySignerAddress(this.hashToSign(), this.signatures).map(
-      joinSignature,
-    );
+    const hash = this.hashToSign();
+    const signaturesList = sortSignaturesBySignerAddress(hash, this.signatures).map(joinSignature);
 
     const txData = new Interface(MinimumViableMultisig.abi).functions.execTransaction.encode([
       multisigInput.to,

--- a/modules/cf-core/src/ethereum/multisig-commitment.ts
+++ b/modules/cf-core/src/ethereum/multisig-commitment.ts
@@ -60,9 +60,5 @@ export abstract class MultisigCommitment implements EthereumCommitment {
     if (!this.signatures || this.signatures.length === 0) {
       throw new Error(`No signatures detected`);
     }
-
-    if (typeof this.signatures[0] === "string") {
-      throw new Error(`Expected Signature type, not string`);
-    }
   }
 }

--- a/modules/cf-core/src/ethereum/set-state-commitment.ts
+++ b/modules/cf-core/src/ethereum/set-state-commitment.ts
@@ -38,19 +38,21 @@ export class SetStateCommitment implements EthereumCommitment {
     this.participantSignatures = sigs;
   }
 
-  public hashToSign(): string {
-    return keccak256(
-      solidityPack(
-        ["bytes1", "bytes32", "uint256", "uint256", "bytes32"],
-        [
-          "0x19",
-          appIdentityToHash(this.appIdentity),
-          this.versionNumber,
-          this.timeout,
-          this.appStateHash,
-        ],
-      ),
+  public encode(): string {
+    return solidityPack(
+      ["bytes1", "bytes32", "uint256", "uint256", "bytes32"],
+      [
+        "0x19",
+        appIdentityToHash(this.appIdentity),
+        this.versionNumber,
+        this.timeout,
+        this.appStateHash,
+      ],
     );
+  }
+
+  public hashToSign(): string {
+    return keccak256(this.encode());
   }
 
   public getSignedTransaction(): CFCoreTypes.MinimalTransaction {

--- a/modules/cf-core/src/ethereum/set-state-commitment.ts
+++ b/modules/cf-core/src/ethereum/set-state-commitment.ts
@@ -1,4 +1,4 @@
-import { Interface, joinSignature, keccak256, Signature, solidityPack } from "ethers/utils";
+import { Interface, keccak256, solidityPack } from "ethers/utils";
 
 import { ChallengeRegistry } from "../contracts";
 import {
@@ -22,14 +22,14 @@ export class SetStateCommitment implements EthereumCommitment {
     public readonly versionNumber: number, // app nonce
     public readonly timeout: number,
     public readonly appIdentityHash: string = appIdentityToHash(appIdentity),
-    private participantSignatures: Signature[] = [],
+    private participantSignatures: string[] = [],
   ) {}
 
-  get signatures(): Signature[] {
+  get signatures(): string[] {
     return this.participantSignatures;
   }
 
-  set signatures(sigs: Signature[]) {
+  set signatures(sigs: string[]) {
     if (sigs.length < 2) {
       throw new Error(
         `Incorrect number of signatures supplied. Expected at least 2, got ${sigs.length}`,
@@ -95,7 +95,7 @@ export class SetStateCommitment implements EthereumCommitment {
       appStateHash: this.appStateHash,
       versionNumber: this.versionNumber,
       timeout: this.timeout,
-      signatures: sortSignaturesBySignerAddress(hash, this.signatures).map(joinSignature),
+      signatures: sortSignaturesBySignerAddress(hash, this.signatures),
     };
   }
 

--- a/modules/cf-core/src/ethereum/set-state-commitment.ts
+++ b/modules/cf-core/src/ethereum/set-state-commitment.ts
@@ -90,13 +90,12 @@ export class SetStateCommitment implements EthereumCommitment {
 
   private getSignedStateHashUpdate(): SignedStateHashUpdate {
     this.assertSignatures();
+    const hash = this.hashToSign();
     return {
       appStateHash: this.appStateHash,
       versionNumber: this.versionNumber,
       timeout: this.timeout,
-      signatures: sortSignaturesBySignerAddress(this.hashToSign(), this.signatures).map(
-        joinSignature,
-      ),
+      signatures: sortSignaturesBySignerAddress(hash, this.signatures).map(joinSignature),
     };
   }
 

--- a/modules/cf-core/src/node.ts
+++ b/modules/cf-core/src/node.ts
@@ -28,7 +28,7 @@ import {
   NodeMessageWrappedProtocolMessage,
   ProtocolMessage,
 } from "./types";
-import { timeout } from "./utils";
+import { timeout, signDigestWithEthers } from "./utils";
 import { Store } from "./store";
 import {
   ConditionalTransactionCommitment,
@@ -177,9 +177,10 @@ export class Node {
       const [commitment, overrideKeyIndex] = args;
       const keyIndex = overrideKeyIndex || 0;
 
-      const signingKey = new SigningKey(await this.privateKeyGetter.getPrivateKey(keyIndex));
+      const privateKey = await this.privateKeyGetter.getPrivateKey(keyIndex);
+      const hash = commitment.hashToSign();
 
-      return signingKey.signDigest(commitment.hashToSign());
+      return signDigestWithEthers(privateKey, hash);
     });
 
     protocolRunner.register(Opcode.IO_SEND, async (args: [ProtocolMessage]) => {

--- a/modules/cf-core/src/protocol/utils/signature-validator.ts
+++ b/modules/cf-core/src/protocol/utils/signature-validator.ts
@@ -5,7 +5,7 @@ import { EthereumCommitment } from "../../types";
 export function assertIsValidSignature(
   expectedSigner: string,
   commitment?: EthereumCommitment,
-  signature?: Signature,
+  signature?: string,
 ) {
   if (commitment === undefined) {
     throw Error("assertIsValidSignature received an undefined commitment");

--- a/modules/cf-core/src/protocol/utils/signature-validator.ts
+++ b/modules/cf-core/src/protocol/utils/signature-validator.ts
@@ -15,12 +15,14 @@ export function assertIsValidSignature(
     throw Error("assertIsValidSignature received an undefined signature");
   }
 
+  const hash = commitment.hashToSign();
+
   // recoverAddress: 83 ms, hashToSign: 7 ms
-  const signer = recoverAddress(commitment.hashToSign(), signature);
+  const signer = recoverAddress(hash, signature);
 
   if (getAddress(expectedSigner) !== signer) {
     throw Error(
-      `Validating a signature with expected signer ${expectedSigner} but recovered ${signer} for commitment hash ${commitment.hashToSign()}.`,
+      `Validating a signature with expected signer ${expectedSigner} but recovered ${signer} for commitment hash ${hash}.`,
     );
   }
 }

--- a/modules/cf-core/src/utils.ts
+++ b/modules/cf-core/src/utils.ts
@@ -10,7 +10,6 @@ import {
   joinSignature,
   keccak256,
   recoverAddress,
-  Signature,
   solidityKeccak256,
   SigningKey,
 } from "ethers/utils";
@@ -53,31 +52,17 @@ export const deBigNumberifyJson = (json: object) =>
   JSON.parse(JSON.stringify(json), (key, val) =>
     val && BigNumber.isBigNumber(val) ? val.toHexString() : val,
   );
-/**
- * Converts an array of signatures into a single string
- *
- * @param signatures An array of etherium signatures
- */
-export function signaturesToBytes(...signatures: Signature[]): string {
-  return signatures
-    .map(joinSignature)
-    .map(s => s.substr(2))
-    .reduce((acc, v) => acc + v, "0x");
-}
 
 /**
  * Sorts signatures in ascending order of signer address
  *
  * @param signatures An array of etherium signatures
  */
-export function sortSignaturesBySignerAddress(
-  digest: string,
-  signatures: Signature[],
-): Signature[] {
+export function sortSignaturesBySignerAddress(digest: string, signatures: string[]): string[] {
   const ret = signatures.slice();
   ret.sort((sigA, sigB) => {
-    const addrA = recoverAddress(digest, signaturesToBytes(sigA));
-    const addrB = recoverAddress(digest, signaturesToBytes(sigB));
+    const addrA = recoverAddress(digest, sigA);
+    const addrB = recoverAddress(digest, sigB);
     return new BigNumber(addrA).lt(addrB) ? -1 : 1;
   });
   return ret;

--- a/modules/cf-core/src/utils.ts
+++ b/modules/cf-core/src/utils.ts
@@ -12,6 +12,7 @@ import {
   recoverAddress,
   solidityKeccak256,
   SigningKey,
+  arrayify,
 } from "ethers/utils";
 import { fromExtendedKey } from "ethers/utils/hdnode";
 
@@ -261,5 +262,5 @@ export function assertSufficientFundsWithinFreeBalance(
 
 export const signDigestWithEthers = (privateKey: string, digest: string) => {
   const signingKey = new SigningKey(privateKey);
-  return joinSignature(signingKey.signDigest(digest));
+  return joinSignature(signingKey.signDigest(arrayify(digest)));
 };

--- a/modules/cf-core/src/utils.ts
+++ b/modules/cf-core/src/utils.ts
@@ -12,6 +12,7 @@ import {
   recoverAddress,
   Signature,
   solidityKeccak256,
+  SigningKey,
 } from "ethers/utils";
 import { fromExtendedKey } from "ethers/utils/hdnode";
 
@@ -285,3 +286,8 @@ export function assertSufficientFundsWithinFreeBalance(
     );
   }
 }
+
+export const signDigestWithEthers = (privateKey: string, digest: string) => {
+  const signingKey = new SigningKey(privateKey);
+  return joinSignature(signingKey.signDigest(digest));
+};

--- a/modules/cf-core/src/utils.ts
+++ b/modules/cf-core/src/utils.ts
@@ -96,19 +96,6 @@ export function sortStringSignaturesBySignerAddress(
   return ret;
 }
 
-/**
- * Sorts signatures in ascending order of signer address
- * and converts them into bytes
- *
- * @param signatures An array of etherium signatures
- */
-export function signaturesToBytesSortedBySignerAddress(
-  digest: string,
-  ...signatures: Signature[]
-): string {
-  return signaturesToBytes(...sortSignaturesBySignerAddress(digest, signatures));
-}
-
 export function prettyPrintObject(object: any) {
   return JSON.stringify(object, null, JSON_STRINGIFY_SPACE);
 }

--- a/modules/cf-core/test/machine/integration/install-then-set-state.spec.ts
+++ b/modules/cf-core/test/machine/integration/install-then-set-state.spec.ts
@@ -152,9 +152,11 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         identityAppInstance.timeout,
       );
 
+      const setStateCommitmentHash = setStateCommitment.hashToSign();
+
       setStateCommitment.signatures = [
-        uniqueAppSigningKeys[0].signDigest(setStateCommitment.hashToSign()),
-        uniqueAppSigningKeys[1].signDigest(setStateCommitment.hashToSign()),
+        uniqueAppSigningKeys[0].signDigest(setStateCommitmentHash),
+        uniqueAppSigningKeys[1].signDigest(setStateCommitmentHash),
       ];
 
       await wallet.sendTransaction({
@@ -169,9 +171,10 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
         stateChannel.freeBalance.versionNumber,
         stateChannel.freeBalance.timeout,
       );
+      const setStateCommitmentForFreeBalanceHash = setStateCommitmentForFreeBalance.hashToSign();
       setStateCommitmentForFreeBalance.signatures = [
-        multisigOwnerKeys[0].signDigest(setStateCommitmentForFreeBalance.hashToSign()),
-        multisigOwnerKeys[1].signDigest(setStateCommitmentForFreeBalance.hashToSign()),
+        multisigOwnerKeys[0].signDigest(setStateCommitmentForFreeBalanceHash),
+        multisigOwnerKeys[1].signDigest(setStateCommitmentForFreeBalanceHash),
       ];
 
       await wallet.sendTransaction({
@@ -205,10 +208,10 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
           [identityAppInstance.multiAssetMultiPartyCoinTransferInterpreterParams!],
         ),
       );
-
+      const conditionalTransactionHash = conditionalTransaction.hashToSign();
       conditionalTransaction.signatures = [
-        multisigOwnerKeys[0].signDigest(conditionalTransaction.hashToSign()),
-        multisigOwnerKeys[1].signDigest(conditionalTransaction.hashToSign()),
+        multisigOwnerKeys[0].signDigest(conditionalTransactionHash),
+        multisigOwnerKeys[1].signDigest(conditionalTransactionHash),
       ];
       const multisigDelegateCallTx = conditionalTransaction.getSignedTransaction();
 

--- a/modules/cf-core/test/machine/integration/install-then-set-state.spec.ts
+++ b/modules/cf-core/test/machine/integration/install-then-set-state.spec.ts
@@ -30,6 +30,7 @@ import { transferERC20Tokens } from "../../integration/utils";
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
 import { extendedPrvKeyToExtendedPubKey, getRandomExtendedPrvKeys } from "./random-signing-keys";
+import { signDigestWithEthers } from "../../../src/utils";
 
 // ProxyFactory.createProxy uses assembly `call` so we can't estimate
 // gas needed, so we hard-code this number to ensure the tx completes
@@ -155,8 +156,8 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
       const setStateCommitmentHash = setStateCommitment.hashToSign();
 
       setStateCommitment.signatures = [
-        uniqueAppSigningKeys[0].signDigest(setStateCommitmentHash),
-        uniqueAppSigningKeys[1].signDigest(setStateCommitmentHash),
+        signDigestWithEthers(uniqueAppSigningKeys[0].privateKey, setStateCommitmentHash),
+        signDigestWithEthers(uniqueAppSigningKeys[1].privateKey, setStateCommitmentHash),
       ];
 
       await wallet.sendTransaction({
@@ -173,8 +174,8 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
       );
       const setStateCommitmentForFreeBalanceHash = setStateCommitmentForFreeBalance.hashToSign();
       setStateCommitmentForFreeBalance.signatures = [
-        multisigOwnerKeys[0].signDigest(setStateCommitmentForFreeBalanceHash),
-        multisigOwnerKeys[1].signDigest(setStateCommitmentForFreeBalanceHash),
+        signDigestWithEthers(multisigOwnerKeys[0].privateKey, setStateCommitmentForFreeBalanceHash),
+        signDigestWithEthers(multisigOwnerKeys[1].privateKey, setStateCommitmentForFreeBalanceHash),
       ];
 
       await wallet.sendTransaction({
@@ -210,8 +211,8 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
       );
       const conditionalTransactionHash = conditionalTransaction.hashToSign();
       conditionalTransaction.signatures = [
-        multisigOwnerKeys[0].signDigest(conditionalTransactionHash),
-        multisigOwnerKeys[1].signDigest(conditionalTransactionHash),
+        signDigestWithEthers(multisigOwnerKeys[0].privateKey, conditionalTransactionHash),
+        signDigestWithEthers(multisigOwnerKeys[1].privateKey, conditionalTransactionHash),
       ];
       const multisigDelegateCallTx = conditionalTransaction.getSignedTransaction();
 
@@ -251,8 +252,14 @@ describe("Scenario: install AppInstance, set state, put on-chain", () => {
       );
 
       freeBalanceConditionalTransaction.signatures = [
-        multisigOwnerKeys[0].signDigest(freeBalanceConditionalTransaction.hashToSign()),
-        multisigOwnerKeys[1].signDigest(freeBalanceConditionalTransaction.hashToSign()),
+        signDigestWithEthers(
+          multisigOwnerKeys[0].privateKey,
+          freeBalanceConditionalTransaction.hashToSign(),
+        ),
+        signDigestWithEthers(
+          multisigOwnerKeys[1].privateKey,
+          freeBalanceConditionalTransaction.hashToSign(),
+        ),
       ];
 
       const multisigDelegateCallTx2 = freeBalanceConditionalTransaction.getSignedTransaction();

--- a/modules/cf-core/test/machine/integration/mininode.ts
+++ b/modules/cf-core/test/machine/integration/mininode.ts
@@ -1,6 +1,5 @@
 import { NetworkContext, nullLogger, PersistAppType, AppInstanceProposal } from "@connext/types";
 import { JsonRpcProvider } from "ethers/providers";
-import { SigningKey } from "ethers/utils";
 import { HDNode } from "ethers/utils/hdnode";
 
 import { EthereumCommitment } from "../../../src/types";
@@ -9,6 +8,7 @@ import { StateChannel, AppInstance } from "../../../src/models";
 import { Store } from "../../../src/store";
 
 import { getRandomHDNodes } from "./random-signing-keys";
+import { signDigestWithEthers } from "../../../src/utils";
 
 /// Returns a function that can be registered with IO_SEND{_AND_WAIT}
 const makeSigner = (hdNode: HDNode) => {
@@ -20,9 +20,10 @@ const makeSigner = (hdNode: HDNode) => {
     const [commitment, overrideKeyIndex] = args;
     const keyIndex = overrideKeyIndex || 0;
 
-    const signingKey = new SigningKey(hdNode.derivePath(`${keyIndex}`).privateKey);
+    const privateKey = hdNode.derivePath(`${keyIndex}`).privateKey;
+    const hash = commitment.hashToSign();
 
-    return signingKey.signDigest(commitment.hashToSign());
+    return signDigestWithEthers(privateKey, hash);
   };
 };
 

--- a/modules/cf-core/test/machine/integration/protocols/test-runner.ts
+++ b/modules/cf-core/test/machine/integration/protocols/test-runner.ts
@@ -190,7 +190,6 @@ export class TestRunner {
       xkeyKthAddress(this.mininodeA.xpub, 1),
       xkeyKthAddress(this.mininodeB.xpub, 1),
     ]);
-    console.log("participants", participants);
 
     await this.mininodeA.protocolRunner.initiateProtocol(Protocol.Install, {
       appInterface: {
@@ -255,7 +254,6 @@ export class TestRunner {
       xkeyKthAddress(this.mininodeA.xpub, 1),
       xkeyKthAddress(this.mininodeB.xpub, 1),
     ]);
-    console.log("participants", participants);
 
     await this.mininodeA.protocolRunner.initiateProtocol(Protocol.Install, {
       participants,

--- a/modules/cf-core/test/machine/integration/protocols/test-runner.ts
+++ b/modules/cf-core/test/machine/integration/protocols/test-runner.ts
@@ -190,6 +190,7 @@ export class TestRunner {
       xkeyKthAddress(this.mininodeA.xpub, 1),
       xkeyKthAddress(this.mininodeB.xpub, 1),
     ]);
+    console.log("participants", participants);
 
     await this.mininodeA.protocolRunner.initiateProtocol(Protocol.Install, {
       appInterface: {
@@ -254,6 +255,7 @@ export class TestRunner {
       xkeyKthAddress(this.mininodeA.xpub, 1),
       xkeyKthAddress(this.mininodeB.xpub, 1),
     ]);
+    console.log("participants", participants);
 
     await this.mininodeA.protocolRunner.initiateProtocol(Protocol.Install, {
       participants,

--- a/modules/cf-core/test/machine/integration/set-state.spec.ts
+++ b/modules/cf-core/test/machine/integration/set-state.spec.ts
@@ -62,9 +62,11 @@ describe("set state on free balance", () => {
       freeBalanceETH.versionNumber,
       freeBalanceETH.timeout,
     );
+    const setStateCommitmentHash = setStateCommitment.hashToSign();
+
     setStateCommitment.signatures = [
-      multisigOwnerKeys[0].signDigest(setStateCommitment.hashToSign()),
-      multisigOwnerKeys[1].signDigest(setStateCommitment.hashToSign()),
+      multisigOwnerKeys[0].signDigest(setStateCommitmentHash),
+      multisigOwnerKeys[1].signDigest(setStateCommitmentHash),
     ];
 
     const setStateTx = setStateCommitment.getSignedTransaction();

--- a/modules/cf-core/test/machine/integration/set-state.spec.ts
+++ b/modules/cf-core/test/machine/integration/set-state.spec.ts
@@ -12,6 +12,7 @@ import { ChallengeRegistry } from "../../contracts";
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
 import { extendedPrvKeyToExtendedPubKey, getRandomExtendedPrvKeys } from "./random-signing-keys";
+import { signDigestWithEthers } from "../../../src/utils";
 
 // The ChallengeRegistry.setState call _could_ be estimated but we haven't
 // written this test to do that yet
@@ -65,8 +66,8 @@ describe("set state on free balance", () => {
     const setStateCommitmentHash = setStateCommitment.hashToSign();
 
     setStateCommitment.signatures = [
-      multisigOwnerKeys[0].signDigest(setStateCommitmentHash),
-      multisigOwnerKeys[1].signDigest(setStateCommitmentHash),
+      signDigestWithEthers(multisigOwnerKeys[0].privateKey, setStateCommitmentHash),
+      signDigestWithEthers(multisigOwnerKeys[1].privateKey, setStateCommitmentHash),
     ];
 
     const setStateTx = setStateCommitment.getSignedTransaction();

--- a/modules/cf-core/test/machine/integration/setup-then-set-state.spec.ts
+++ b/modules/cf-core/test/machine/integration/setup-then-set-state.spec.ts
@@ -89,9 +89,10 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
         freeBalance.versionNumber,
         freeBalance.timeout,
       );
+      const setStateCommitmentHash = setStateCommitment.hashToSign();
       setStateCommitment.signatures = [
-        multisigOwnerKeys[0].signDigest(setStateCommitment.hashToSign()),
-        multisigOwnerKeys[1].signDigest(setStateCommitment.hashToSign()),
+        multisigOwnerKeys[0].signDigest(setStateCommitmentHash),
+        multisigOwnerKeys[1].signDigest(setStateCommitmentHash),
       ];
 
       const setStateTx = setStateCommitment.getSignedTransaction();
@@ -113,10 +114,11 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
         stateChannel.multisigOwners,
         stateChannel.freeBalance.identity,
       );
+      const setupCommitmentHash = setupCommitment.hashToSign();
 
       setupCommitment.signatures = [
-        multisigOwnerKeys[0].signDigest(setupCommitment.hashToSign()),
-        multisigOwnerKeys[1].signDigest(setupCommitment.hashToSign()),
+        multisigOwnerKeys[0].signDigest(setupCommitmentHash),
+        multisigOwnerKeys[1].signDigest(setupCommitmentHash),
       ];
 
       const setupTx = setupCommitment.getSignedTransaction();

--- a/modules/cf-core/test/machine/integration/setup-then-set-state.spec.ts
+++ b/modules/cf-core/test/machine/integration/setup-then-set-state.spec.ts
@@ -10,7 +10,7 @@ import { SetStateCommitment, SetupCommitment } from "../../../src/ethereum";
 import { xkeysToSortedKthSigningKeys } from "../../../src/machine";
 import { StateChannel } from "../../../src/models";
 import { FreeBalanceClass } from "../../../src/models/free-balance";
-import { getCreate2MultisigAddress } from "../../../src/utils";
+import { getCreate2MultisigAddress, signDigestWithEthers } from "../../../src/utils";
 
 import { toBeEq } from "./bignumber-jest-matcher";
 import { connectToGanache } from "./connect-ganache";
@@ -91,8 +91,8 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
       );
       const setStateCommitmentHash = setStateCommitment.hashToSign();
       setStateCommitment.signatures = [
-        multisigOwnerKeys[0].signDigest(setStateCommitmentHash),
-        multisigOwnerKeys[1].signDigest(setStateCommitmentHash),
+        signDigestWithEthers(multisigOwnerKeys[0].privateKey, setStateCommitmentHash),
+        signDigestWithEthers(multisigOwnerKeys[1].privateKey, setStateCommitmentHash),
       ];
 
       const setStateTx = setStateCommitment.getSignedTransaction();
@@ -117,8 +117,8 @@ describe("Scenario: Setup, set state on free balance, go on chain", () => {
       const setupCommitmentHash = setupCommitment.hashToSign();
 
       setupCommitment.signatures = [
-        multisigOwnerKeys[0].signDigest(setupCommitmentHash),
-        multisigOwnerKeys[1].signDigest(setupCommitmentHash),
+        signDigestWithEthers(multisigOwnerKeys[0].privateKey, setupCommitmentHash),
+        signDigestWithEthers(multisigOwnerKeys[1].privateKey, setupCommitmentHash),
       ];
 
       const setupTx = setupCommitment.getSignedTransaction();

--- a/modules/cf-core/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
+++ b/modules/cf-core/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
@@ -19,6 +19,7 @@ import { createAppInstanceForTest } from "../../../unit/utils";
 import { getRandomExtendedPubKey, getRandomHDNodes } from "../../integration/random-signing-keys";
 import { generateRandomNetworkContext } from "../../mocks";
 import { Store } from "../../../../src/store";
+import { signDigestWithEthers } from "../../../../src/utils";
 
 describe("ConditionalTransactionCommitment", () => {
   let tx: MultisigTransaction;
@@ -85,9 +86,10 @@ describe("ConditionalTransactionCommitment", () => {
       await store.saveConditionalTransactionCommitment(commitment.appIdentityHash, commitment);
       const retrieved = await store.getConditionalTransactionCommitment(commitment.appIdentityHash);
       expect(retrieved).toMatchObject(commitment);
+      const hash = randomBytes(20).toString();
       commitment.signatures = [
-        new SigningKey(hdNodes[0]).signDigest(randomBytes(20)),
-        new SigningKey(hdNodes[1]).signDigest(randomBytes(20)),
+        new SigningKey(hdNodes[0]).signDigest(hash),
+        new SigningKey(hdNodes[1]).signDigest(hash),
       ];
       await store.saveConditionalTransactionCommitment(commitment.appIdentityHash, commitment);
       const signed = await store.getConditionalTransactionCommitment(commitment.appIdentityHash);

--- a/modules/cf-core/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
+++ b/modules/cf-core/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
@@ -1,13 +1,6 @@
 import { MemoryStorage as MemoryStoreService } from "@connext/store";
 import { AddressZero, HashZero, WeiPerEther } from "ethers/constants";
-import {
-  getAddress,
-  hexlify,
-  Interface,
-  randomBytes,
-  TransactionDescription,
-  SigningKey,
-} from "ethers/utils";
+import { getAddress, hexlify, Interface, randomBytes, TransactionDescription } from "ethers/utils";
 
 import { CONVENTION_FOR_ETH_TOKEN_ADDRESS } from "../../../../src/constants";
 import { appIdentityToHash, ConditionalTransactionCommitment } from "../../../../src/ethereum";
@@ -88,8 +81,8 @@ describe("ConditionalTransactionCommitment", () => {
       expect(retrieved).toMatchObject(commitment);
       const hash = randomBytes(20).toString();
       commitment.signatures = [
-        new SigningKey(hdNodes[0]).signDigest(hash),
-        new SigningKey(hdNodes[1]).signDigest(hash),
+        signDigestWithEthers(hdNodes[0].privateKey, hash),
+        signDigestWithEthers(hdNodes[1].privateKey, hash),
       ];
       await store.saveConditionalTransactionCommitment(commitment.appIdentityHash, commitment);
       const signed = await store.getConditionalTransactionCommitment(commitment.appIdentityHash);

--- a/modules/cf-core/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
+++ b/modules/cf-core/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
@@ -79,7 +79,7 @@ describe("ConditionalTransactionCommitment", () => {
       await store.saveConditionalTransactionCommitment(commitment.appIdentityHash, commitment);
       const retrieved = await store.getConditionalTransactionCommitment(commitment.appIdentityHash);
       expect(retrieved).toMatchObject(commitment);
-      const hash = Buffer.from(randomBytes(20)).toString("hex");
+      const hash = "0x" + Buffer.from(randomBytes(20)).toString("hex");
       commitment.signatures = [
         signDigestWithEthers(hdNodes[0].privateKey, hash),
         signDigestWithEthers(hdNodes[1].privateKey, hash),

--- a/modules/cf-core/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
+++ b/modules/cf-core/test/machine/unit/ethereum/conditional-transaction-commitment.spec.ts
@@ -79,7 +79,7 @@ describe("ConditionalTransactionCommitment", () => {
       await store.saveConditionalTransactionCommitment(commitment.appIdentityHash, commitment);
       const retrieved = await store.getConditionalTransactionCommitment(commitment.appIdentityHash);
       expect(retrieved).toMatchObject(commitment);
-      const hash = randomBytes(20).toString();
+      const hash = Buffer.from(randomBytes(20)).toString("hex");
       commitment.signatures = [
         signDigestWithEthers(hdNodes[0].privateKey, hash),
         signDigestWithEthers(hdNodes[1].privateKey, hash),

--- a/modules/cf-core/test/machine/unit/ethereum/set-state-commitment.spec.ts
+++ b/modules/cf-core/test/machine/unit/ethereum/set-state-commitment.spec.ts
@@ -5,7 +5,6 @@ import {
   keccak256,
   solidityPack,
   TransactionDescription,
-  SigningKey,
 } from "ethers/utils";
 
 import { appIdentityToHash, SetStateCommitment } from "../../../../src/ethereum";
@@ -13,6 +12,7 @@ import { ChallengeRegistry } from "../../../contracts";
 import { createAppInstanceForTest } from "../../../unit/utils";
 import { generateRandomNetworkContext } from "../../mocks";
 import { getRandomHDNodes } from "../../integration/random-signing-keys";
+import { signDigestWithEthers } from "../../../../src/utils";
 
 /**
  * This test suite decodes a constructed SetState Commitment transaction object
@@ -39,8 +39,8 @@ describe("Set State Commitment", () => {
     );
     const commitmentHash = commitment.hashToSign();
     commitment.signatures = [
-      new SigningKey(hdNodes[0].privateKey).signDigest(commitmentHash),
-      new SigningKey(hdNodes[1].privateKey).signDigest(commitmentHash),
+      signDigestWithEthers(hdNodes[0].privateKey, commitmentHash),
+      signDigestWithEthers(hdNodes[1].privateKey, commitmentHash),
     ];
     // TODO: (question) Should there be a way to retrieve the version
     //       of this transaction sent to the multisig vs sent

--- a/modules/cf-core/test/machine/unit/ethereum/set-state-commitment.spec.ts
+++ b/modules/cf-core/test/machine/unit/ethereum/set-state-commitment.spec.ts
@@ -37,9 +37,10 @@ describe("Set State Commitment", () => {
       appInstance.versionNumber,
       appInstance.timeout,
     );
+    const commitmentHash = commitment.hashToSign();
     commitment.signatures = [
-      new SigningKey(hdNodes[0].privateKey).signDigest(commitment.hashToSign()),
-      new SigningKey(hdNodes[1].privateKey).signDigest(commitment.hashToSign()),
+      new SigningKey(hdNodes[0].privateKey).signDigest(commitmentHash),
+      new SigningKey(hdNodes[1].privateKey).signDigest(commitmentHash),
     ];
     // TODO: (question) Should there be a way to retrieve the version
     //       of this transaction sent to the multisig vs sent

--- a/modules/cf-core/test/machine/unit/protocol/signature-validator.spec.ts
+++ b/modules/cf-core/test/machine/unit/protocol/signature-validator.spec.ts
@@ -3,10 +3,11 @@ import { hexlify, randomBytes, recoverAddress, Signature, SigningKey } from "eth
 
 import { EthereumCommitment } from "../../../../src/types";
 import { assertIsValidSignature } from "../../../../src/protocol/utils/signature-validator";
+import { signDigestWithEthers } from "../../../../src/utils";
 
 describe("Signature Validator Helper", () => {
   let signer: SigningKey;
-  let signature: Signature;
+  let signature: string;
   let commitment: EthereumCommitment;
 
   beforeEach(() => {
@@ -16,7 +17,7 @@ describe("Signature Validator Helper", () => {
       hashToSign: () => HashZero,
     } as EthereumCommitment;
     const commitmentHash = commitment.hashToSign();
-    signature = signer.signDigest(commitmentHash);
+    signature = signDigestWithEthers(signer.privateKey, commitmentHash);
   });
 
   it("validates signatures correctly", () => {
@@ -38,7 +39,7 @@ describe("Signature Validator Helper", () => {
   it("throws if the signature is wrong", () => {
     const rightHash = commitment.hashToSign();
     const wrongHash = HashZero.replace("00", "11"); // 0x11000...
-    const signature = signer.signDigest(wrongHash);
+    const signature = signDigestWithEthers(signer.privateKey, wrongHash);
     const wrongSigner = recoverAddress(rightHash, signature);
     expect(() => assertIsValidSignature(signer.address, commitment, signature)).toThrow(
       `Validating a signature with expected signer ${signer.address} but recovered ${wrongSigner} for commitment hash ${rightHash}`,

--- a/modules/cf-core/test/machine/unit/protocol/signature-validator.spec.ts
+++ b/modules/cf-core/test/machine/unit/protocol/signature-validator.spec.ts
@@ -15,8 +15,8 @@ describe("Signature Validator Helper", () => {
     commitment = {
       hashToSign: () => HashZero,
     } as EthereumCommitment;
-
-    signature = signer.signDigest(commitment.hashToSign());
+    const commitmentHash = commitment.hashToSign();
+    signature = signer.signDigest(commitmentHash);
   });
 
   it("validates signatures correctly", () => {

--- a/modules/channel-provider/src/channelProvider.ts
+++ b/modules/channel-provider/src/channelProvider.ts
@@ -1,6 +1,6 @@
 import {
   chan_config,
-  chan_signWithdrawCommitment,
+  chan_signDigest,
   chan_restoreState,
   chan_getUserWithdrawal,
   chan_setUserWithdrawal,
@@ -11,7 +11,7 @@ import {
   IChannelProvider,
   IRpcConnection,
   JsonRpcRequest,
-  chan_nodeAuth,
+  chan_signMessage,
   StateChannelJSON,
   WithdrawalMonitorObject,
 } from "@connext/types";
@@ -60,12 +60,12 @@ export class ChannelProvider extends ConnextEventEmitter implements IChannelProv
       case chan_getUserWithdrawal:
         result = await this.getUserWithdrawal();
         break;
-      case chan_signWithdrawCommitment:
-        result = await this.signWithdrawCommitment(params.message);
+      case chan_signDigest:
+        result = await this.signDigest(params.message);
         break;
-      case chan_nodeAuth:
-          result = await this.signMessage(params.message);
-          break;
+      case chan_signMessage:
+        result = await this.signMessage(params.message);
+        break;
       case chan_config:
         result = this.config;
         break;
@@ -134,11 +134,11 @@ export class ChannelProvider extends ConnextEventEmitter implements IChannelProv
   /// // SIGNING METHODS
 
   public signMessage = async (message: string): Promise<string> => {
-    return this._send(chan_nodeAuth, { message });
+    return this._send(chan_signMessage, { message });
   };
 
-  public signWithdrawCommitment = async (message: string): Promise<string> => {
-    return this._send(chan_signWithdrawCommitment, { message });
+  public signDigest = async (message: string): Promise<string> => {
+    return this._send(chan_signDigest, { message });
   };
   /// ////////////////////////////////////////////
   /// // STORE METHODS
@@ -154,7 +154,7 @@ export class ChannelProvider extends ConnextEventEmitter implements IChannelProv
   };
 
   public restoreState = async (): Promise<void> => {
-    return this._send(chan_restoreState, { });
+    return this._send(chan_restoreState, {});
   };
 
   public setStateChannel = async (state: StateChannelJSON): Promise<void> => {

--- a/modules/client/src/channelProvider.ts
+++ b/modules/client/src/channelProvider.ts
@@ -1,8 +1,8 @@
 import {
-  chan_nodeAuth,
+  chan_signMessage,
   chan_getUserWithdrawal,
   chan_setUserWithdrawal,
-  chan_signWithdrawCommitment,
+  chan_signDigest,
   chan_setStateChannel,
   chan_restoreState,
   IChannelProvider,
@@ -83,11 +83,11 @@ export class CFCoreRpcConnection extends ConnextEventEmitter implements IRpcConn
       case chan_getUserWithdrawal:
         result = await this.storeGetUserWithdrawal();
         break;
-      case chan_signWithdrawCommitment:
-        result = await this.signWithdrawCommitment(params.message);
+      case chan_signDigest:
+        result = await this.signDigest(params.message);
         break;
-      case chan_nodeAuth:
-        result = await this.walletSign(params.message);
+      case chan_signMessage:
+        result = await this.signMessage(params.message);
         break;
       case chan_restoreState:
         result = await this.restoreState();
@@ -128,11 +128,11 @@ export class CFCoreRpcConnection extends ConnextEventEmitter implements IRpcConn
 
   ///////////////////////////////////////////////
   ///// PRIVATE METHODS
-  private walletSign = async (message: string): Promise<string> => {
+  private signMessage = async (message: string): Promise<string> => {
     return signEthereumMessage(this.authKey, message);
   };
 
-  private signWithdrawCommitment = async (message: string): Promise<string> => {
+  private signDigest = async (message: string): Promise<string> => {
     return signDigestWithEthers(this.authKey, message);
   };
 

--- a/modules/client/src/channelProvider.ts
+++ b/modules/client/src/channelProvider.ts
@@ -12,7 +12,7 @@ import {
   WithdrawalMonitorObject,
 } from "@connext/types";
 import { ChannelProvider } from "@connext/channel-provider";
-import { signEthereumMessage } from "@connext/crypto";
+import { signChannelMessage } from "@connext/crypto";
 
 import { CFCore, deBigNumberifyJson, xpubToAddress, signDigestWithEthers } from "./lib";
 import {
@@ -129,7 +129,7 @@ export class CFCoreRpcConnection extends ConnextEventEmitter implements IRpcConn
   ///////////////////////////////////////////////
   ///// PRIVATE METHODS
   private signMessage = async (message: string): Promise<string> => {
-    return signEthereumMessage(this.authKey, message);
+    return signChannelMessage(this.authKey, message);
   };
 
   private signDigest = async (message: string): Promise<string> => {

--- a/modules/client/src/controllers/WithdrawalController.ts
+++ b/modules/client/src/controllers/WithdrawalController.ts
@@ -46,7 +46,7 @@ export class WithdrawalController extends AbstractController {
     await this.cleanupPendingDeposit(params.assetId);
 
     const withdrawCommitment = await this.createWithdrawCommitment(params);
-    const withdrawerSignatureOnWithdrawCommitment = await this.connext.channelProvider.signWithdrawCommitment(
+    const withdrawerSignatureOnWithdrawCommitment = await this.connext.channelProvider.signDigest(
       withdrawCommitment.hashToSign(),
     );
 
@@ -83,7 +83,7 @@ export class WithdrawalController extends AbstractController {
     } as WithdrawParameters<BigNumber>);
 
     // Dont need to validate anything because we already did it during the propose flow
-    const counterpartySignatureOnWithdrawCommitment = await this.connext.channelProvider.signWithdrawCommitment(
+    const counterpartySignatureOnWithdrawCommitment = await this.connext.channelProvider.signDigest(
       generatedCommitment.hashToSign(),
     );
     await this.connext.takeAction(appInstance.identityHash, {

--- a/modules/client/src/controllers/WithdrawalController.ts
+++ b/modules/client/src/controllers/WithdrawalController.ts
@@ -46,15 +46,12 @@ export class WithdrawalController extends AbstractController {
     await this.cleanupPendingDeposit(params.assetId);
 
     const withdrawCommitment = await this.createWithdrawCommitment(params);
+    const hash = withdrawCommitment.hashToSign();
     const withdrawerSignatureOnWithdrawCommitment = await this.connext.channelProvider.signDigest(
-      withdrawCommitment.hashToSign(),
+      hash,
     );
 
-    await this.proposeWithdrawApp(
-      params,
-      withdrawCommitment.hashToSign(),
-      withdrawerSignatureOnWithdrawCommitment,
-    );
+    await this.proposeWithdrawApp(params, hash, withdrawerSignatureOnWithdrawCommitment);
 
     this.connext.listener.emit(EventNames[WITHDRAWAL_STARTED_EVENT], {
       params,
@@ -81,10 +78,11 @@ export class WithdrawalController extends AbstractController {
       assetId: appInstance.singleAssetTwoPartyCoinTransferInterpreterParams.tokenAddress,
       recipient: state.transfers[0].to,
     } as WithdrawParameters<BigNumber>);
+    const hash = generatedCommitment.hashToSign();
 
     // Dont need to validate anything because we already did it during the propose flow
     const counterpartySignatureOnWithdrawCommitment = await this.connext.channelProvider.signDigest(
-      generatedCommitment.hashToSign(),
+      hash,
     );
     await this.connext.takeAction(appInstance.identityHash, {
       signature: counterpartySignatureOnWithdrawCommitment,

--- a/modules/client/src/lib/crypto.spec.ts
+++ b/modules/client/src/lib/crypto.spec.ts
@@ -14,7 +14,8 @@ import {
 } from "@connext/crypto";
 import * as EthCrypto from "eth-crypto";
 import { Wallet } from "ethers";
-import { SigningKey, computePublicKey, arrayify, joinSignature } from "ethers/utils";
+import { computePublicKey, arrayify } from "ethers/utils";
+import { signDigestWithEthers } from "./utils";
 
 const prvKey = Wallet.createRandom().privateKey;
 const pubKey = removeHexPrefix(computePublicKey(prvKey));
@@ -83,8 +84,7 @@ describe("crypto", () => {
   });
 
   test("we should be able to sign ECDSA digests", async () => {
-    const signingKey = new SigningKey(wallet.privateKey);
-    const sig1 = joinSignature(signingKey.signDigest(arrayify(digest)));
+    const sig1 = signDigestWithEthers(wallet.privateKey, arrayify(digest).toString());
     const sig2 = await signDigest(wallet.privateKey, digest);
     expect(sig1).toEqual(sig2);
   });

--- a/modules/client/src/lib/crypto.spec.ts
+++ b/modules/client/src/lib/crypto.spec.ts
@@ -11,6 +11,8 @@ import {
   keccak256,
   utf8ToBuffer,
   removeHexPrefix,
+  bufferToHex,
+  addHexPrefix,
 } from "@connext/crypto";
 import * as EthCrypto from "eth-crypto";
 import { Wallet } from "ethers";
@@ -84,7 +86,7 @@ describe("crypto", () => {
   });
 
   test("we should be able to sign ECDSA digests", async () => {
-    const sig1 = signDigestWithEthers(wallet.privateKey, arrayify(digest).toString());
+    const sig1 = signDigestWithEthers(wallet.privateKey, bufferToHex(digest, true));
     const sig2 = await signDigest(wallet.privateKey, digest);
     expect(sig1).toEqual(sig2);
   });

--- a/modules/client/src/lib/utils.ts
+++ b/modules/client/src/lib/utils.ts
@@ -111,6 +111,6 @@ export const createPaymentId = createRandom32ByteHexString;
 export const createPreImage = createRandom32ByteHexString;
 
 export const signDigestWithEthers = (privateKey: string, digest: string) => {
-  const key = new SigningKey(privateKey);
-  return joinSignature(key.signDigest(digest));
+  const signingKey = new SigningKey(privateKey);
+  return joinSignature(signingKey.signDigest(digest));
 };

--- a/modules/client/src/lib/utils.ts
+++ b/modules/client/src/lib/utils.ts
@@ -7,6 +7,7 @@ import {
   solidityKeccak256,
   joinSignature,
   SigningKey,
+  arrayify,
 } from "ethers/utils";
 import { isNullOrUndefined } from "util";
 
@@ -112,5 +113,5 @@ export const createPreImage = createRandom32ByteHexString;
 
 export const signDigestWithEthers = (privateKey: string, digest: string) => {
   const signingKey = new SigningKey(privateKey);
-  return joinSignature(signingKey.signDigest(digest));
+  return joinSignature(signingKey.signDigest(arrayify(digest)));
 };

--- a/modules/client/src/node.ts
+++ b/modules/client/src/node.ts
@@ -26,7 +26,7 @@ import {
   Transfer,
 } from "./types";
 import { invalidXpub } from "./validation";
-import { chan_nodeAuth } from "@connext/types";
+import { chan_signMessage } from "@connext/types";
 
 // Include our access token when interacting with these subjects
 const guardedSubjects = [];
@@ -280,7 +280,9 @@ export class NodeApiClient implements INodeApiClient {
       if (unsignedToken.expiry < Date.now()) {
         throw new Error("Got expired authentication nonce from hub - this shouldnt happen!");
       }
-      const sig = await this.channelProvider.send(chan_nodeAuth, { message: unsignedToken.nonce });
+      const sig = await this.channelProvider.send(chan_signMessage, {
+        message: unsignedToken.nonce,
+      });
       this._authToken = token = {
         expiry: unsignedToken.expiry,
         value: `${unsignedToken.nonce}:${sig}`,

--- a/modules/contracts/test/adjudicator/challenge-registry.spec.ts
+++ b/modules/contracts/test/adjudicator/challenge-registry.spec.ts
@@ -3,14 +3,7 @@ import { waffle as buidler } from "@nomiclabs/buidler";
 import * as waffle from "ethereum-waffle";
 import { Contract, Wallet } from "ethers";
 import { HashZero } from "ethers/constants";
-import {
-  BigNumberish,
-  hexlify,
-  joinSignature,
-  keccak256,
-  randomBytes,
-  SigningKey,
-} from "ethers/utils";
+import { BigNumberish, hexlify, keccak256, randomBytes } from "ethers/utils";
 
 import ChallengeRegistry from "../../build/ChallengeRegistry.json";
 import {
@@ -18,6 +11,7 @@ import {
   computeAppChallengeHash,
   expect,
   sortSignaturesBySignerAddress,
+  signDigestWithEthers,
 } from "./utils";
 
 type Challenge = {
@@ -97,9 +91,9 @@ describe("ChallengeRegistry", () => {
       await appRegistry.functions.cancelChallenge(
         appIdentityTestObject.appIdentity,
         sortSignaturesBySignerAddress(digest, [
-          await new SigningKey(ALICE.privateKey).signDigest(digest),
-          await new SigningKey(BOB.privateKey).signDigest(digest),
-        ]).map(joinSignature),
+          await signDigestWithEthers(ALICE.privateKey, digest),
+          await signDigestWithEthers(BOB.privateKey, digest),
+        ]),
       );
     };
 
@@ -120,9 +114,9 @@ describe("ChallengeRegistry", () => {
         versionNumber,
         appStateHash: stateHash,
         signatures: sortSignaturesBySignerAddress(digest, [
-          await new SigningKey(ALICE.privateKey).signDigest(digest),
-          await new SigningKey(BOB.privateKey).signDigest(digest),
-        ]).map(joinSignature),
+          await signDigestWithEthers(ALICE.privateKey, digest),
+          await signDigestWithEthers(BOB.privateKey, digest),
+        ]),
       });
     };
 

--- a/modules/contracts/test/adjudicator/utils/index.ts
+++ b/modules/contracts/test/adjudicator/utils/index.ts
@@ -95,16 +95,3 @@ export function sortSignaturesBySignerAddress(
   });
   return ret;
 }
-
-/**
- * Sorts signatures in ascending order of signer address
- * and converts them into bytes
- *
- * @param signatures An array of etherium signatures
- */
-export function signaturesToBytesSortedBySignerAddress(
-  digest: string,
-  ...signatures: Signature[]
-): string {
-  return signaturesToBytes(...sortSignaturesBySignerAddress(digest, signatures));
-}

--- a/modules/contracts/test/adjudicator/utils/index.ts
+++ b/modules/contracts/test/adjudicator/utils/index.ts
@@ -10,6 +10,7 @@ import {
   recoverAddress,
   SigningKey,
   solidityPack,
+  arrayify,
 } from "ethers/utils";
 
 export const expect = chai.use(solidity).expect;
@@ -88,5 +89,5 @@ export function sortSignaturesBySignerAddress(digest: string, signatures: string
  */
 export const signDigestWithEthers = (privateKey: string, digest: string) => {
   const signingKey = new SigningKey(privateKey);
-  return joinSignature(signingKey.signDigest(digest));
+  return joinSignature(signingKey.signDigest(arrayify(digest)));
 };

--- a/modules/contracts/test/adjudicator/utils/index.ts
+++ b/modules/contracts/test/adjudicator/utils/index.ts
@@ -8,7 +8,7 @@ import {
   joinSignature,
   keccak256,
   recoverAddress,
-  Signature,
+  SigningKey,
   solidityPack,
 } from "ethers/utils";
 
@@ -67,31 +67,26 @@ export class AppIdentityTestClass {
 }
 
 /**
- * Converts an array of signatures into a single string
- *
- * @param signatures An array of etherium signatures
- */
-export function signaturesToBytes(...signatures: Signature[]): string {
-  return signatures
-    .map(joinSignature)
-    .map(s => s.substr(2))
-    .reduce((acc, v) => acc + v, "0x");
-}
-
-/**
  * Sorts signatures in ascending order of signer address
  *
  * @param signatures An array of etherium signatures
  */
-export function sortSignaturesBySignerAddress(
-  digest: string,
-  signatures: Signature[],
-): Signature[] {
+export function sortSignaturesBySignerAddress(digest: string, signatures: string[]): string[] {
   const ret = signatures.slice();
   ret.sort((sigA, sigB) => {
-    const addrA = recoverAddress(digest, signaturesToBytes(sigA));
-    const addrB = recoverAddress(digest, signaturesToBytes(sigB));
+    const addrA = recoverAddress(digest, sigA);
+    const addrB = recoverAddress(digest, sigB);
     return new BigNumber(addrA).lt(addrB) ? -1 : 1;
   });
   return ret;
 }
+
+/**
+ * Signs digest with ethers SigningKey
+ *
+ * @param signatures An array of etherium signatures
+ */
+export const signDigestWithEthers = (privateKey: string, digest: string) => {
+  const signingKey = new SigningKey(privateKey);
+  return joinSignature(signingKey.signDigest(digest));
+};

--- a/modules/contracts/test/funding/utils/index.ts
+++ b/modules/contracts/test/funding/utils/index.ts
@@ -33,16 +33,3 @@ export function sortSignaturesBySignerAddress(
   });
   return ret;
 }
-
-/**
- * Sorts signatures in ascending order of signer address
- * and converts them into bytes
- *
- * @param signatures An array of etherium signatures
- */
-export function signaturesToBytesSortedBySignerAddress(
-  digest: string,
-  ...signatures: Signature[]
-): string {
-  return signaturesToBytes(...sortSignaturesBySignerAddress(digest, signatures));
-}

--- a/modules/contracts/test/funding/utils/index.ts
+++ b/modules/contracts/test/funding/utils/index.ts
@@ -1,34 +1,19 @@
 import * as chai from "chai";
 import { solidity } from "ethereum-waffle";
-import { BigNumber, joinSignature, recoverAddress, Signature } from "ethers/utils";
+import { BigNumber, recoverAddress } from "ethers/utils";
 
 export const expect = chai.use(solidity).expect;
-
-/**
- * Converts an array of signatures into a single string
- *
- * @param signatures An array of etherium signatures
- */
-export function signaturesToBytes(...signatures: Signature[]): string {
-  return signatures
-    .map(joinSignature)
-    .map(s => s.substr(2))
-    .reduce((acc, v) => acc + v, "0x");
-}
 
 /**
  * Sorts signatures in ascending order of signer address
  *
  * @param signatures An array of etherium signatures
  */
-export function sortSignaturesBySignerAddress(
-  digest: string,
-  signatures: Signature[],
-): Signature[] {
+export function sortSignaturesBySignerAddress(digest: string, signatures: string[]): string[] {
   const ret = signatures.slice();
   ret.sort((sigA, sigB) => {
-    const addrA = recoverAddress(digest, signaturesToBytes(sigA));
-    const addrB = recoverAddress(digest, signaturesToBytes(sigB));
+    const addrA = recoverAddress(digest, sigA);
+    const addrB = recoverAddress(digest, sigB);
     return new BigNumber(addrA).lt(addrB) ? -1 : 1;
   });
   return ret;

--- a/modules/contracts/test/funding/withdraw-app.spec.ts
+++ b/modules/contracts/test/funding/withdraw-app.spec.ts
@@ -1,13 +1,21 @@
 /* global before */
 import { waffle as buidler } from "@nomiclabs/buidler";
-import { WithdrawAppState, WithdrawAppAction, CoinTransfer, singleAssetTwoPartyCoinTransferEncoding, WithdrawAppStateEncoding, WithdrawAppActionEncoding } from "@connext/types";
+import {
+  WithdrawAppState,
+  WithdrawAppAction,
+  CoinTransfer,
+  singleAssetTwoPartyCoinTransferEncoding,
+  WithdrawAppStateEncoding,
+  WithdrawAppActionEncoding,
+} from "@connext/types";
 import chai from "chai";
 import * as waffle from "ethereum-waffle";
 import { Contract, Wallet } from "ethers";
-import { BigNumber, defaultAbiCoder, joinSignature, SigningKey } from "ethers/utils";
+import { BigNumber, defaultAbiCoder, SigningKey } from "ethers/utils";
 
-import WithdrawApp from "../../build/WithdrawApp.json"
+import WithdrawApp from "../../build/WithdrawApp.json";
 import { Zero, HashZero } from "ethers/constants";
+import { signDigestWithEthers } from "../adjudicator/utils";
 
 const { expect } = chai;
 
@@ -31,7 +39,7 @@ const encodeAppState = (
 
 const encodeAppAction = (state: WithdrawAppAction): string => {
   return defaultAbiCoder.encode([WithdrawAppActionEncoding], [state]);
-}
+};
 
 describe("WithdrawApp", async () => {
   let provider = buidler.provider;
@@ -44,17 +52,14 @@ describe("WithdrawApp", async () => {
   const data = mkHash("0xa"); // TODO: test this with real withdrawal commitment hash?
   const withdrawerSigningKey = new SigningKey(withdrawerWallet.privateKey);
   const counterpartySigningKey = new SigningKey(counterpartyWallet.privateKey);
-  
+
   const computeOutcome = async (state: WithdrawAppState<string>): Promise<string> => {
     return await withdrawApp.functions.computeOutcome(encodeAppState(state));
-  }
-  
+  };
+
   const applyAction = async (state: any, action: WithdrawAppAction): Promise<string> => {
-    return await withdrawApp.functions.applyAction(
-      encodeAppState(state),
-      encodeAppAction(action),
-    );
-  }
+    return await withdrawApp.functions.applyAction(encodeAppState(state), encodeAppAction(action));
+  };
 
   const createInitialState = (): WithdrawAppState<string> => {
     return {
@@ -68,21 +73,20 @@ describe("WithdrawApp", async () => {
           to: counterpartyWallet.address,
         },
       ],
-      signatures: [joinSignature(withdrawerSigningKey.signDigest(data)), HashZero],
+      signatures: [signDigestWithEthers(withdrawerSigningKey.privateKey, data), HashZero],
       signers: [withdrawerWallet.address, counterpartyWallet.address],
       data,
       finalized: false,
     };
-  }
+  };
 
   const createAction = (): WithdrawAppAction => {
     return {
-      signature: joinSignature(counterpartySigningKey.signDigest(data))
+      signature: signDigestWithEthers(counterpartySigningKey.privateKey, data),
     };
-  }
+  };
 
-  beforeEach(async () => {
-  });
+  beforeEach(async () => {});
 
   describe("It zeroes withdrawer balance if state is finalized (w/ valid signatures)", async () => {
     let initialState = createInitialState();
@@ -100,7 +104,7 @@ describe("WithdrawApp", async () => {
     expect(decoded[0].amount).eq(Zero.toString());
     expect(decoded[1].to).eq(initialState.transfers[1].to);
     expect(decoded[1].amount).eq(Zero);
-  })
+  });
 
   describe("It cancels the withdrawal if state is not finalized", async () => {
     let initialState = createInitialState();
@@ -113,7 +117,7 @@ describe("WithdrawApp", async () => {
     expect(decoded[0].amount).eq(initialState.transfers[0].amount);
     expect(decoded[1].to).eq(initialState.transfers[1].to);
     expect(decoded[1].amount).eq(Zero.toString());
-  })
+  });
 
   describe("It reverts the action if state is finalized", async () => {
     let initialState = createInitialState();
@@ -124,22 +128,24 @@ describe("WithdrawApp", async () => {
     expect(afterActionState.signatures[1]).to.eq(action.signature);
     expect(afterActionState.finalized).to.be.true;
 
-    await expect(applyAction(afterActionState, action)).revertedWith("cannot take action on a finalized state")
-  })
+    await expect(applyAction(afterActionState, action)).revertedWith(
+      "cannot take action on a finalized state",
+    );
+  });
 
   describe("It reverts the action if withdrawer signature is invalid", async () => {
     let initialState = createInitialState();
     let action = createAction();
 
     initialState.signatures[0] = mkHash("0x0");
-    await expect(applyAction(initialState, action)).revertedWith("invalid withdrawer signature")
-  })
+    await expect(applyAction(initialState, action)).revertedWith("invalid withdrawer signature");
+  });
 
   describe("It reverts the action if counterparty signature is invalid", async () => {
     let initialState = createInitialState();
     let action = createAction();
 
     action.signature = HashZero;
-    await expect(applyAction(initialState, action)).revertedWith("invalid counterparty signature")
-  })
+    await expect(applyAction(initialState, action)).revertedWith("invalid counterparty signature");
+  });
 });

--- a/modules/crypto/src/index.ts
+++ b/modules/crypto/src/index.ts
@@ -15,6 +15,7 @@ import {
   recover,
   isHexString,
   arrayToBuffer,
+  removeHexPrefix,
 } from "eccrypto-js";
 
 export * from "eccrypto-js";
@@ -33,6 +34,7 @@ export function bufferify(input: any[] | Buffer | string | Uint8Array): Buffer {
 }
 
 export function toChecksumAddress(address: string): string {
+  address = removeHexPrefix(address);
   const hash = bufferToHex(keccak256(utf8ToBuffer(address)));
   let checksum = "";
   for (let i = 0; i < address.length; i++) {
@@ -49,7 +51,7 @@ export function getEthereumAddress(publicKey: Buffer | string): string {
   const buf = bufferify(publicKey);
   const hex = addHexPrefix(bufferToHex(buf).slice(2));
   const hash = keccak256(hexToBuffer(hex));
-  const address = bufferToHex(hash, true).substring(26);
+  const address = addHexPrefix(bufferToHex(hash).substring(24));
   return toChecksumAddress(address);
 }
 

--- a/modules/crypto/src/index.ts
+++ b/modules/crypto/src/index.ts
@@ -22,18 +22,14 @@ export * from "eccrypto-js";
 export const ETH_SIGN_PREFIX = "\x19Ethereum Signed Message:\n";
 export const CHAN_SIGN_PREFIX = "\x19Channel Signed Message:\n";
 
-export function anyToBuffer(input: any[] | Buffer | string | Uint8Array): Buffer {
+export function bufferify(input: any[] | Buffer | string | Uint8Array): Buffer {
   return typeof input === "string"
     ? isHexString(input)
       ? hexToBuffer(input)
       : utf8ToBuffer(input)
-    : Buffer.isBuffer(input)
-    ? input
-    : arrayToBuffer(new Uint8Array(input));
-}
-
-export function ensureBuffer(value: Buffer | string): Buffer {
-  return Buffer.isBuffer(value) ? value : utf8ToBuffer(value);
+    : !Buffer.isBuffer(input)
+    ? arrayToBuffer(new Uint8Array(input))
+    : input;
 }
 
 export function toChecksumAddress(address: string): string {
@@ -50,7 +46,7 @@ export function toChecksumAddress(address: string): string {
 }
 
 export function getEthereumAddress(publicKey: Buffer | string): string {
-  const buf = anyToBuffer(publicKey);
+  const buf = bufferify(publicKey);
   const hex = addHexPrefix(bufferToHex(buf).slice(2));
   const hash = keccak256(hexToBuffer(hex));
   const address = bufferToHex(hash, true).substring(26);
@@ -58,9 +54,9 @@ export function getEthereumAddress(publicKey: Buffer | string): string {
 }
 
 export function hashMessage(message: Buffer | string, prefix: string): string {
-  const data = ensureBuffer(message);
-  const length = anyToBuffer(`${data.length}`);
-  const hash = keccak256(concatBuffers(anyToBuffer(prefix), length, data));
+  const data = bufferify(message);
+  const length = bufferify(`${data.length}`);
+  const hash = keccak256(concatBuffers(bufferify(prefix), length, data));
   return bufferToHex(hash, true);
 }
 
@@ -83,7 +79,7 @@ export async function signDigest(
   privateKey: Buffer | string,
   digest: Buffer | string,
 ): Promise<string> {
-  return bufferToHex(await sign(anyToBuffer(privateKey), ensureBuffer(digest), true), true);
+  return bufferToHex(await sign(bufferify(privateKey), bufferify(digest), true), true);
 }
 
 export async function signMessage(
@@ -92,7 +88,7 @@ export async function signMessage(
   prefix: string,
 ): Promise<string> {
   const hash = hashMessage(message, prefix);
-  return signDigest(privateKey, anyToBuffer(hash));
+  return signDigest(privateKey, bufferify(hash));
 }
 
 export async function signEthereumMessage(
@@ -113,7 +109,7 @@ export async function recoverPublicKey(
   digest: Buffer | string,
   sig: Buffer | string,
 ): Promise<string> {
-  return bufferToHex(await recover(anyToBuffer(digest), anyToBuffer(sig)), true);
+  return bufferToHex(await recover(bufferify(digest), bufferify(sig)), true);
 }
 
 export async function recoverAddress(

--- a/modules/node/package.json
+++ b/modules/node/package.json
@@ -25,6 +25,7 @@
     "@connext/apps": "6.0.0-alpha.0",
     "@connext/cf-core": "6.0.0-alpha.0",
     "@connext/contracts": "1.0.5",
+    "@connext/crypto": "6.0.0-alpha.0",
     "@connext/messaging": "6.0.0-alpha.0",
     "@connext/types": "6.0.0-alpha.0",
     "@nestjs/common": "7.0.2",

--- a/modules/node/src/conditionalCommitment/conditionalCommitment.entity.ts
+++ b/modules/node/src/conditionalCommitment/conditionalCommitment.entity.ts
@@ -27,7 +27,7 @@ export class ConditionalTransactionCommitment {
   multisigOwners!: string[];
 
   @Column("json", { nullable: true })
-  signatures!: Signature[];
+  signatures!: string[];
 
   @OneToOne((type: any) => AppInstance)
   @JoinColumn()

--- a/modules/node/src/setStateCommitment/setStateCommitment.entity.ts
+++ b/modules/node/src/setStateCommitment/setStateCommitment.entity.ts
@@ -21,7 +21,7 @@ export class SetStateCommitment {
   challengeRegistryAddress!: string;
 
   @Column("json", { nullable: true })
-  signatures!: Signature[];
+  signatures!: string[];
 
   @Column("integer")
   timeout!: number;

--- a/modules/node/src/util/utils.ts
+++ b/modules/node/src/util/utils.ts
@@ -1,4 +1,4 @@
-import { getAddress } from "ethers/utils";
+import { SigningKey, joinSignature, getAddress } from "ethers/utils";
 
 import { isEthAddress } from "./validate";
 
@@ -21,4 +21,9 @@ export const safeJsonParse = (value: any): any => {
   } catch {
     return value;
   }
+};
+
+export const signDigestWithEthers = (privateKey: string, digest: string) => {
+  const signingKey = new SigningKey(privateKey);
+  return joinSignature(signingKey.signDigest(digest));
 };

--- a/modules/node/src/util/utils.ts
+++ b/modules/node/src/util/utils.ts
@@ -1,4 +1,4 @@
-import { SigningKey, joinSignature, getAddress } from "ethers/utils";
+import { SigningKey, joinSignature, getAddress, arrayify } from "ethers/utils";
 
 import { isEthAddress } from "./validate";
 
@@ -25,5 +25,5 @@ export const safeJsonParse = (value: any): any => {
 
 export const signDigestWithEthers = (privateKey: string, digest: string) => {
   const signingKey = new SigningKey(privateKey);
-  return joinSignature(signingKey.signDigest(digest));
+  return joinSignature(signingKey.signDigest(arrayify(digest)));
 };

--- a/modules/node/src/withdraw/withdraw.service.ts
+++ b/modules/node/src/withdraw/withdraw.service.ts
@@ -6,7 +6,7 @@ import { ConfigService } from "../config/config.service";
 import { LoggerService } from "../logger/logger.service";
 import { OnchainTransactionService } from "../onchainTransactions/onchainTransaction.service";
 import { OnchainTransactionRepository } from "../onchainTransactions/onchainTransaction.repository";
-import { CFCoreTypes, xkeyKthAddress } from "../util";
+import { CFCoreTypes, xkeyKthAddress, signDigestWithEthers } from "../util";
 import {
   TransactionResponse,
   AppInstanceJson,
@@ -18,7 +18,7 @@ import {
   WithdrawAppAction,
 } from "@connext/types";
 import { HashZero, Zero, AddressZero } from "ethers/constants";
-import { SigningKey, joinSignature, bigNumberify } from "ethers/utils";
+import { bigNumberify } from "ethers/utils";
 import { Channel } from "../channel/channel.entity";
 import { ChannelRepository } from "../channel/channel.repository";
 import { WithdrawRepository } from "../withdraw/withdraw.repository";
@@ -93,11 +93,12 @@ export class WithdrawService {
       appInstance.multisigAddress,
     );
 
+    // Get Private Key
+    const { privateKey } = this.configService.getEthWallet();
+
     // Sign commitment
-    const signingKey = new SigningKey(this.configService.getEthWallet().privateKey);
-    const counterpartySignatureOnWithdrawCommitment = joinSignature(
-      signingKey.signDigest(generatedCommitment.hashToSign()),
-    );
+    const hash = generatedCommitment.hashToSign();
+    const counterpartySignatureOnWithdrawCommitment = signDigestWithEthers(privateKey, hash);
 
     await this.cfCoreService.takeAction(appInstance.identityHash, {
       signature: counterpartySignatureOnWithdrawCommitment,
@@ -226,10 +227,10 @@ export class WithdrawService {
       channel.multisigAddress,
     );
 
-    const signingKey = new SigningKey(this.configService.getEthWallet().privateKey);
-    const withdrawerSignatureOnCommitment = joinSignature(
-      signingKey.signDigest(commitment.hashToSign()),
-    );
+    const { privateKey } = this.configService.getEthWallet();
+    const hash = commitment.hashToSign();
+
+    const withdrawerSignatureOnCommitment = signDigestWithEthers(privateKey, hash);
 
     const transfers: CoinTransfer[] = [
       { amount: amount.toString(), to: this.cfCoreService.cfCore.freeBalanceAddress },

--- a/modules/node/src/withdraw/withdraw.service.ts
+++ b/modules/node/src/withdraw/withdraw.service.ts
@@ -94,7 +94,7 @@ export class WithdrawService {
     );
 
     // Get Private Key
-    const { privateKey } = this.configService.getEthWallet();
+    const privateKey = this.configService.getEthWallet().privateKey;
 
     // Sign commitment
     const hash = generatedCommitment.hashToSign();
@@ -227,7 +227,7 @@ export class WithdrawService {
       channel.multisigAddress,
     );
 
-    const { privateKey } = this.configService.getEthWallet();
+    const privateKey = this.configService.getEthWallet().privateKey;
     const hash = commitment.hashToSign();
 
     const withdrawerSignatureOnCommitment = signDigestWithEthers(privateKey, hash);

--- a/modules/node/src/withdraw/withdraw.service.ts
+++ b/modules/node/src/withdraw/withdraw.service.ts
@@ -244,7 +244,7 @@ export class WithdrawService {
         this.cfCoreService.cfCore.freeBalanceAddress,
         xkeyKthAddress(channel.userPublicIdentifier),
       ],
-      data: commitment.hashToSign(),
+      data: hash,
       finalized: false,
     };
 

--- a/modules/node/src/withdraw/withdraw.service.ts
+++ b/modules/node/src/withdraw/withdraw.service.ts
@@ -94,9 +94,9 @@ export class WithdrawService {
     );
 
     // Sign commitment
-    const key = new SigningKey(this.configService.getEthWallet().privateKey);
+    const signingKey = new SigningKey(this.configService.getEthWallet().privateKey);
     const counterpartySignatureOnWithdrawCommitment = joinSignature(
-      key.signDigest(generatedCommitment.hashToSign()),
+      signingKey.signDigest(generatedCommitment.hashToSign()),
     );
 
     await this.cfCoreService.takeAction(appInstance.identityHash, {

--- a/modules/test-runner/src/flows/multiclientFastSignedTransfer.test.ts
+++ b/modules/test-runner/src/flows/multiclientFastSignedTransfer.test.ts
@@ -2,19 +2,11 @@ import {
   IConnextClient,
   ReceiveTransferFinishedEventData,
   FastSignedTransferParameters,
-  delay,
   CREATE_TRANSFER,
   CreateTransferEventData,
   ResolveFastSignedTransferParameters,
 } from "@connext/types";
-import {
-  bigNumberify,
-  hexlify,
-  randomBytes,
-  solidityKeccak256,
-  joinSignature,
-  SigningKey,
-} from "ethers/utils";
+import { bigNumberify, hexlify, randomBytes, solidityKeccak256, SigningKey } from "ethers/utils";
 import { before, after } from "mocha";
 import { Client } from "ts-nats";
 
@@ -22,6 +14,7 @@ import { env, expect, Logger, createClient, fundChannel, connectNats, closeNats 
 import { Wallet } from "ethers";
 import { One, AddressZero } from "ethers/constants";
 import { clientA } from "../benchmarking/flamegraphPrep";
+import { signDigestWithEthers } from "@connext/cf-core/dist/src/utils";
 
 describe("Full Flow: Multi-client transfer", () => {
   let log = new Logger("MultiClientTransfer", env.logLevel);
@@ -142,7 +135,7 @@ describe("Full Flow: Multi-client transfer", () => {
           }
           const data = hexlify(randomBytes(32));
           const digest = solidityKeccak256(["bytes32", "bytes32"], [data, eventData.paymentId]);
-          const signature = joinSignature(withdrawerSigningKey!.signDigest(digest));
+          const signature = signDigestWithEthers(withdrawerSigningKey!.privateKey, digest);
 
           await indexer!.resolveCondition({
             conditionType: "FAST_SIGNED_TRANSFER",

--- a/modules/test-runner/src/flows/multiclientTransfer.test.ts
+++ b/modules/test-runner/src/flows/multiclientTransfer.test.ts
@@ -40,7 +40,6 @@ describe("Full Flow: Multi-client transfer", () => {
       received: 0,
     };
     const startTime = Date.now();
-    console.log("startTime", startTime);
     await new Promise(async (res, rej) => {
       await fundChannel(gateway, bigNumberify(100));
       gateway.on(

--- a/modules/test-runner/src/flows/multiclientTransfer.test.ts
+++ b/modules/test-runner/src/flows/multiclientTransfer.test.ts
@@ -40,6 +40,7 @@ describe("Full Flow: Multi-client transfer", () => {
       received: 0,
     };
     const startTime = Date.now();
+    console.log("startTime", startTime);
     await new Promise(async (res, rej) => {
       await fundChannel(gateway, bigNumberify(100));
       gateway.on(

--- a/modules/test-runner/src/transfer/fastSignedTransfer.test.ts
+++ b/modules/test-runner/src/transfer/fastSignedTransfer.test.ts
@@ -10,20 +10,13 @@ import {
   delay,
   ResolveConditionResponse,
 } from "@connext/types";
-import {
-  hexlify,
-  randomBytes,
-  bigNumberify,
-  BigNumber,
-  solidityKeccak256,
-  SigningKey,
-  joinSignature,
-} from "ethers/utils";
+import { hexlify, randomBytes, bigNumberify, BigNumber, solidityKeccak256 } from "ethers/utils";
 import { Wallet } from "ethers";
 import { AddressZero, One, Zero } from "ethers/constants";
 
 import { createClient, fundChannel, expect } from "../util";
 import { xkeyKthAddress } from "@connext/cf-core";
+import { signDigestWithEthers } from "@connext/cf-core/dist/src/utils";
 
 describe.skip("Fast Signed Transfer", () => {
   let clientA: IConnextClient;
@@ -80,9 +73,8 @@ describe.skip("Fast Signed Transfer", () => {
 
     const data = hexlify(randomBytes(32));
 
-    const withdrawerSigningKey = new SigningKey(signerWallet.privateKey);
     const digest = solidityKeccak256(["bytes32", "bytes32"], [data, paymentId]);
-    const signature = joinSignature(withdrawerSigningKey.signDigest(digest));
+    const signature = signDigestWithEthers(signerWallet.privateKey, digest);
 
     let resolveCondition: ResolveConditionResponse;
     await new Promise(async resolve => {
@@ -140,7 +132,7 @@ describe.skip("Fast Signed Transfer", () => {
 
       const withdrawerSigningKey = new SigningKey(signerWallet.privateKey);
       const digest = solidityKeccak256(["bytes32", "bytes32"], [data, paymentId]);
-      const signature = joinSignature(withdrawerSigningKey.signDigest(digest));
+      const signature = signDigestWithEthers(withdrawerSigningKey.privateKey, digest);
 
       const res = await clientB.resolveCondition({
         conditionType: FAST_SIGNED_TRANSFER,

--- a/modules/test-runner/src/transfer/fastSignedTransfer.test.ts
+++ b/modules/test-runner/src/transfer/fastSignedTransfer.test.ts
@@ -130,9 +130,8 @@ describe.skip("Fast Signed Transfer", () => {
 
       const data = hexlify(randomBytes(32));
 
-      const withdrawerSigningKey = new SigningKey(signerWallet.privateKey);
       const digest = solidityKeccak256(["bytes32", "bytes32"], [data, paymentId]);
-      const signature = signDigestWithEthers(withdrawerSigningKey.privateKey, digest);
+      const signature = signDigestWithEthers(signerWallet.privateKey, digest);
 
       const res = await clientB.resolveCondition({
         conditionType: FAST_SIGNED_TRANSFER,

--- a/modules/types/src/challenge.ts
+++ b/modules/types/src/challenge.ts
@@ -7,7 +7,7 @@ export type SetStateCommitmentJSON = {
   readonly appIdentityHash: string;
   readonly appStateHash: string;
   readonly challengeRegistryAddress: string;
-  readonly signatures: Signature[];
+  readonly signatures: string[];
   readonly timeout: number;
   readonly versionNumber: number;
 };
@@ -20,5 +20,5 @@ export type ConditionalTransactionCommitmentJSON = {
   readonly multisigAddress: string;
   readonly multisigOwners: string[];
   readonly networkContext: NetworkContext;
-  readonly signatures: Signature[];
+  readonly signatures: string[];
 };

--- a/modules/types/src/channelProvider.ts
+++ b/modules/types/src/channelProvider.ts
@@ -35,7 +35,7 @@ export interface IChannelProvider extends ConnextEventEmitter {
   ///////////////////////////////////
   // SIGNING METHODS
   signMessage(message: string): Promise<string>;
-  signWithdrawCommitment(message: any): Promise<string>;
+  signDigest(message: any): Promise<string>;
 
   ///////////////////////////////////
   // STORE METHODS
@@ -45,8 +45,8 @@ export interface IChannelProvider extends ConnextEventEmitter {
 }
 
 export const chan_config = "chan_config";
-export const chan_nodeAuth = "chan_nodeAuth";
-export const chan_signWithdrawCommitment = "chan_signWithdrawCommitment";
+export const chan_signMessage = "chan_signMessage";
+export const chan_signDigest = "chan_signDigest";
 export const chan_restoreState = "chan_restoreState";
 export const chan_setUserWithdrawal = "chan_setUserWithdrawal";
 export const chan_getUserWithdrawal = "chan_getUserWithdrawal";
@@ -56,8 +56,8 @@ export const chan_setStateChannel = "chan_setStateChannel";
 
 export const ConnextRpcMethods = {
   [chan_config]: chan_config,
-  [chan_nodeAuth]: chan_nodeAuth,
-  [chan_signWithdrawCommitment]: chan_signWithdrawCommitment,
+  [chan_signMessage]: chan_signMessage,
+  [chan_signDigest]: chan_signDigest,
   [chan_restoreState]: chan_restoreState,
   [chan_getUserWithdrawal]: chan_getUserWithdrawal,
   [chan_setUserWithdrawal]: chan_setUserWithdrawal,

--- a/modules/types/src/contracts.ts
+++ b/modules/types/src/contracts.ts
@@ -1,7 +1,6 @@
 import { BaseProvider, BigNumber } from "./basic";
 import { CoinBalanceRefundApp } from "./apps";
 import { ProtocolTypes } from "./protocol";
-import { Signature } from "ethers/utils";
 
 ////////////////////////////////////////
 // Generic contract ops & network config
@@ -64,6 +63,7 @@ export interface DeployedContractNetworksFileEntry {
 
 // Multisig
 export interface EthereumCommitment {
+  signatures: string[];
   encode(): string;
   hashToSign(): string;
   getSignedTransaction(): ProtocolTypes.MinimalTransaction;

--- a/modules/types/src/contracts.ts
+++ b/modules/types/src/contracts.ts
@@ -64,6 +64,7 @@ export interface DeployedContractNetworksFileEntry {
 
 // Multisig
 export interface EthereumCommitment {
+  encode(): string;
   hashToSign(): string;
   getSignedTransaction(): ProtocolTypes.MinimalTransaction;
 }


### PR DESCRIPTION
This PR is mostly a preparation PR for a following signing refactor. Basically we currently sign digests and handle digests as the data to sign. This is bad practice for the following reasons:
1. we hash unnecessarily to get the data to sign
2. we expose the wallet signDigest functionality

The first problem is using the commitment hashes as the data for signing which means that we care calling keccak256 simply to evaluate the commitment data even without signing.
Solution is to simply encode the commitment parameters with solidityPack and use them as the data to sign and evaluate.

The second problem is the most critical, since we have auto-signing capabilities in our clients, we are currently exposing the signDigest functionality which will basically allow the wallet to auto-sign any secp256k1 digests.
Solution is to create a new method that uses a Channel-specific hashing prior to signing, therefore the data to be signed can only be used for our use-cases.

Additionally this PR removes some unnecessary mapping that parses Signatures and instead expect them to be formatted as encoded byte strigns
