### PR TITLE
use global localStorage and lazy load it

### DIFF
--- a/modules/store/package.json
+++ b/modules/store/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@connext/types": "6.0.0-alpha.0",
     "ethers": "4.0.45",
+    "localStorage": "1.0.4",
     "pisa-client": "0.1.4-connext-beta.1",
     "uuid": "3.4.0"
   },

--- a/modules/store/src/wrappers/localStorage.ts
+++ b/modules/store/src/wrappers/localStorage.ts
@@ -5,10 +5,11 @@ import {
   COMMITMENT_KEY,
 } from "../helpers";
 import { IBackupServiceAPI, WrappedStorage } from "@connext/types";
-import localStorage from "localStorage";
 
+// @ts-ignore
+const getLocalStorage = () => global.localStorage || require("localStorage");
 export class WrappedLocalStorage implements WrappedStorage {
-  private localStorage: Storage = localStorage;
+  private localStorage: Storage = getLocalStorage();
 
   constructor(
     private readonly prefix: string = DEFAULT_STORE_PREFIX,


### PR DESCRIPTION
Quick fix for 6.0.0-alpha.0
```sh
Error: Cannot find module 'localStorage'
```