### PR TITLE
959/1 add validation to cf

### DIFF
--- a/modules/cf-core/src/machine/middleware.ts
+++ b/modules/cf-core/src/machine/middleware.ts
@@ -19,8 +19,13 @@ export class MiddlewareContainer {
   public async run(opCode: Opcode, args: any[]) {
     const middleware = this.middlewares[opCode][0];
 
+    // it is okay for middleware to be undefined iff
+    // it is the validation opcode
     if (typeof middleware === "undefined") {
-      throw new Error(`Attempted to run middleware for opcode ${opCode} but none existed`);
+      if (opCode !== Opcode.OP_VALIDATE) {
+        throw new Error(`Attempted to run middleware for opcode ${opCode} but none existed`);
+      }
+      return;
     }
 
     return middleware(args);

--- a/modules/cf-core/src/machine/middleware.ts
+++ b/modules/cf-core/src/machine/middleware.ts
@@ -1,16 +1,18 @@
-import { Middleware, Opcode } from "../types";
+import { GenericMiddleware } from "@connext/types";
+import { Opcode } from "../types";
 
 export class MiddlewareContainer {
-  public readonly middlewares: { [I in Opcode]: Middleware[] } = {
+  public readonly middlewares: { [I in Opcode]: GenericMiddleware[] } = {
     [Opcode.IO_SEND]: [],
     [Opcode.IO_SEND_AND_WAIT]: [],
     [Opcode.OP_SIGN]: [],
     [Opcode.PERSIST_APP_INSTANCE]: [],
     [Opcode.PERSIST_COMMITMENT]: [],
     [Opcode.PERSIST_STATE_CHANNEL]: [],
+    [Opcode.OP_VALIDATE]: [],
   };
 
-  public add(scope: Opcode, method: Middleware) {
+  public add(scope: Opcode, method: GenericMiddleware) {
     this.middlewares[scope].push(method);
   }
 

--- a/modules/cf-core/src/machine/protocol-runner.ts
+++ b/modules/cf-core/src/machine/protocol-runner.ts
@@ -1,4 +1,5 @@
 import {
+  GenericMiddleware,
   ILoggerService,
   ProtocolName,
   ProtocolNames,
@@ -12,7 +13,6 @@ import { v4 as uuid } from "uuid";
 import { getProtocolFromName } from "../protocol";
 import {
   Context,
-  Middleware,
   NetworkContext,
   Opcode,
   ProtocolMessage,
@@ -40,7 +40,7 @@ export class ProtocolRunner {
     this.middlewares = new MiddlewareContainer();
   }
 
-  public register(scope: Opcode, method: Middleware) {
+  public register(scope: Opcode, method: GenericMiddleware) {
     this.middlewares.add(scope, method);
   }
 

--- a/modules/cf-core/src/node.ts
+++ b/modules/cf-core/src/node.ts
@@ -8,6 +8,8 @@ import {
   MinimalTransaction,
   nullLogger,
   STORE_SCHEMA_VERSION,
+  ProtocolName,
+  ValidationMiddleware,
 } from "@connext/types";
 import { JsonRpcProvider } from "ethers/providers";
 import { SigningKey } from "ethers/utils";
@@ -167,6 +169,23 @@ export class Node {
   @Memoize()
   get freeBalanceAddress(): string {
     return getFreeBalanceAddress(this.publicIdentifier);
+  }
+
+  /**
+   * Attaches middleware for the chosen opcode. Currently, only `OP_VALIDATE`
+   * is accepted as an injected middleware
+   */
+  public injectMiddleware(
+    opcode: Opcode,
+    middleware: ValidationMiddleware,
+  ): void {
+    if (opcode !== Opcode.OP_VALIDATE) {
+      throw new Error(`Cannot inject middleware for opcode: ${opcode}`);
+    }
+    this.protocolRunner.register(opcode, async (args: [ProtocolName, any]) => {
+      const [protocol, context] = args;
+      return middleware(protocol, context);
+    });
   }
 
   /**

--- a/modules/cf-core/src/node.ts
+++ b/modules/cf-core/src/node.ts
@@ -10,6 +10,7 @@ import {
   STORE_SCHEMA_VERSION,
   ProtocolName,
   ValidationMiddleware,
+  MiddlewareContext,
 } from "@connext/types";
 import { JsonRpcProvider } from "ethers/providers";
 import { SigningKey } from "ethers/utils";
@@ -182,7 +183,10 @@ export class Node {
     if (opcode !== Opcode.OP_VALIDATE) {
       throw new Error(`Cannot inject middleware for opcode: ${opcode}`);
     }
-    this.protocolRunner.register(opcode, async (args: [ProtocolName, any]) => {
+    this.protocolRunner.register(
+      opcode,
+      async (args: [ProtocolName, MiddlewareContext],
+    ) => {
       const [protocol, context] = args;
       return middleware(protocol, context);
     });

--- a/modules/cf-core/src/protocol/install.ts
+++ b/modules/cf-core/src/protocol/install.ts
@@ -1,4 +1,4 @@
-import { ProtocolNames, ProtocolParams } from "@connext/types";
+import { ProtocolNames, ProtocolParams, ProtocolRoles, InstallMiddlewareContext } from "@connext/types";
 import { MaxUint256 } from "ethers/constants";
 import { BigNumber } from "ethers/utils";
 
@@ -26,6 +26,7 @@ import { assertIsValidSignature, stateChannelClassFromStoreByMultisig } from "./
 const protocol = ProtocolNames.install;
 const {
   OP_SIGN,
+  OP_VALIDATE,
   IO_SEND,
   IO_SEND_AND_WAIT,
   PERSIST_APP_INSTANCE,
@@ -92,6 +93,18 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     );
 
     const newAppInstance = stateChannelAfter.mostRecentlyInstalledAppInstance();
+
+    // safe to do here, nothing is signed or written to store
+    yield [
+      OP_VALIDATE,
+      protocol,
+      {
+        params,
+        stateChannel: stateChannelBefore.toJson(),
+        appInstance: newAppInstance.toJson(),
+        role: ProtocolRoles.initiator,
+      } as InstallMiddlewareContext,
+    ];
 
     const conditionalTxCommitment = getConditionalTransactionCommitment(
       context,
@@ -266,6 +279,18 @@ export const INSTALL_PROTOCOL: ProtocolExecutionFlow = {
     const initiatorFreeBalanceAddress = xkeyKthAddress(initiatorXpub, 0);
 
     const newAppInstance = stateChannelAfter.mostRecentlyInstalledAppInstance();
+
+    // safe to do here, nothing is signed or written to store
+    yield [
+      OP_VALIDATE,
+      protocol,
+      {
+        params,
+        stateChannel: stateChannelBefore.toJson(),
+        appInstance: newAppInstance.toJson(),
+        role: ProtocolRoles.responder,
+      } as InstallMiddlewareContext,
+    ];
 
     const conditionalTxCommitment = getConditionalTransactionCommitment(
       context,

--- a/modules/cf-core/src/testing/scenarios/injected-middleware.spec.ts
+++ b/modules/cf-core/src/testing/scenarios/injected-middleware.spec.ts
@@ -1,0 +1,60 @@
+import { ValidationMiddleware, ProtocolNames, ProtocolRoles, ProtocolName, SetupMiddlewareContext } from "@connext/types";
+import { SetupContext, setup } from "../setup";
+import { Node } from "../../node";
+import { getCreate2MultisigAddress } from "../../utils";
+import { Opcode } from "../../types";
+import { createChannel } from "../utils";
+
+describe("injected validation middleware", () => {
+  let nodeA: Node;
+  let nodeB: Node;
+
+  let multisigAddress: string;
+
+  beforeEach(async () => {
+    const context: SetupContext = await setup(global);
+    nodeA = context["A"].node;
+    nodeB = context["B"].node;
+
+    multisigAddress = await getCreate2MultisigAddress(
+      [nodeA.publicIdentifier, nodeB.publicIdentifier].sort(),
+      {
+        proxyFactory: nodeA.networkContext.ProxyFactory,
+        multisigMastercopy: nodeA.networkContext.MinimumViableMultisig,
+      },
+      nodeA.networkContext.provider,
+    );
+  });
+
+  it("can inject validation middleware", async () => {
+    let capturedProtocol: ProtocolName;
+    let capturedContext: SetupMiddlewareContext;
+    const middleware: ValidationMiddleware = async (
+      protocol: ProtocolName,
+      context: SetupMiddlewareContext,
+    ) => {
+      capturedContext = { ...context };
+      capturedProtocol = protocol;
+    };
+    nodeA.injectMiddleware(Opcode.OP_VALIDATE, middleware);
+    await createChannel(nodeA, nodeB);
+    expect(capturedProtocol!).toBe(ProtocolNames.setup);
+    expect(capturedContext!).toEqual({
+      params: {
+        initiatorXpub: nodeA.publicIdentifier,
+        responderXpub: nodeB.publicIdentifier,
+        multisigAddress,
+      },
+      role: ProtocolRoles.initiator,
+    });
+  });
+
+  it("protocol will fail if the validation middleware errors", async () => {
+    const FAILURE_MESSAGE = "Middleware failed";
+    const middleware: ValidationMiddleware = (protocol, context) => {
+      return Promise.reject(FAILURE_MESSAGE);
+    };
+    nodeA.injectMiddleware(Opcode.OP_VALIDATE, middleware);
+    await expect(createChannel(nodeA, nodeB)).rejects.toEqual(FAILURE_MESSAGE);
+  });
+});

--- a/modules/cf-core/src/types.ts
+++ b/modules/cf-core/src/types.ts
@@ -34,6 +34,9 @@ export enum Opcode {
   PERSIST_COMMITMENT,
   // Middleware hook to write the state channel to store. Used to lock channel between protocols.
   PERSIST_STATE_CHANNEL,
+  // Middleware hook to validate state transitions in protocol. Called before
+  // `computeStateTransition` and registered using `injectMiddleware`
+  OP_VALIDATE,
 }
 
 export interface IPrivateKeyGenerator {
@@ -42,10 +45,6 @@ export interface IPrivateKeyGenerator {
 
 export type ProtocolExecutionFlow = {
   [x: number]: (context: Context) => AsyncIterableIterator<any[]>;
-};
-
-export type Middleware = {
-  (args: any): any;
 };
 
 export type Instruction = Function | Opcode;

--- a/modules/types/src/index.ts
+++ b/modules/types/src/index.ts
@@ -25,6 +25,7 @@ export {
   ProtocolParam,
   ProtocolParams,
 } from "./protocol";
+export * from "./middleware";
 export * from "./state";
 export * from "./store";
 export * from "./utils";

--- a/modules/types/src/middleware.ts
+++ b/modules/types/src/middleware.ts
@@ -1,0 +1,62 @@
+import { enumify } from "./utils";
+import { ProtocolParams, ProtocolName } from "./protocol";
+import { AppInstanceProposal, AppInstanceJson } from "./app";
+import { StateChannelJSON } from "./state";
+
+export type GenericMiddleware = {
+  (args: any): any;
+};
+
+////////////////////////////////////////
+// validation middleware
+export const ProtocolRoles = enumify({
+  initiator: "initiator",
+  responder: "responder",
+});
+export type ProtocolRoles = (typeof ProtocolRoles)[keyof typeof ProtocolRoles];
+export type ProtocolRole = keyof typeof ProtocolRoles;
+
+export type SetupMiddlewareContext = {
+  role: ProtocolRole;
+  params: ProtocolParams.Setup;
+};
+export type ProposeMiddlewareContext = {
+  role: ProtocolRole;
+  params: ProtocolParams.Propose;
+  proposal: AppInstanceProposal;
+};
+export type InstallMiddlewareContext = {
+  role: ProtocolRole;
+  params: ProtocolParams.Propose;
+  appInstance: AppInstanceJson;
+  stateChannel: StateChannelJSON;
+};
+export type TakeActionMiddlewareContext = {
+  role: ProtocolRole;
+  params: ProtocolParams.TakeAction;
+  appInstance: AppInstanceJson; // pre-action
+};
+export type UninstallMiddlewareContext = {
+  role: ProtocolRole;
+  params: ProtocolParams.Uninstall;
+  appInstance: AppInstanceJson;
+  stateChannel: StateChannelJSON;
+};
+export type UpdateMiddlewareContext = {
+  role: ProtocolRole;
+  params: ProtocolParams.Update;
+  appInstance: AppInstanceJson; // pre-update
+};
+
+export type MiddlewareContext = 
+  | SetupMiddlewareContext
+  | ProposeMiddlewareContext
+  | InstallMiddlewareContext
+  | TakeActionMiddlewareContext
+  | UninstallMiddlewareContext
+  | UpdateMiddlewareContext
+
+
+export type ValidationMiddleware = {
+  (protocol: ProtocolName, context: MiddlewareContext): Promise<void>;
+};


### PR DESCRIPTION
## The Problem
Fixes #959 

Cf core now accepts validation that can be injected. Has not been implemented on hub or client
