### PR TITLE
✨ Allow contract migrations one off

### DIFF
--- a/modules/contracts/ops/migrate-contracts.js
+++ b/modules/contracts/ops/migrate-contracts.js
@@ -200,7 +200,25 @@ const sendGift = async (address, token) => {
   ////////////////////////////////////////
   // Deploy contracts
 
-  for (const contract of coreContracts.concat(appContracts).sort()) {
+  let contractsToDeploy = [];
+  const knownContracts = coreContracts.concat(appContracts).sort();
+
+  // if args are provided, only deploy given contracts
+  const args = process.argv.slice(2);
+  if (args.length > 0) {
+    args.forEach(contractName => {
+      if (!knownContracts.includes(contractName)) {
+        console.error(`Unknown contract name: ${contractName}`);
+        return;
+      }
+      contractsToDeploy.push(contractName);
+    });
+  } else {
+    contractsToDeploy = knownContracts;
+  }
+  console.log(`Deploying contracts: ${contractsToDeploy}`);
+
+  for (const contract of contractsToDeploy) {
     await deployContract(contract, artifacts[contract], []);
   }
 


### PR DESCRIPTION
<!--- Make sure your title is descriptive -->
<!--- If you have any questions, don't hesitate to reach out to us on Discord! -->

## The Problem
Hard to deploy one-off contracts.

## The Solution
Allow migration script to be run one-off with args defining desired contract deployments.

## Checklist:
<!--- Go over each of the following points & put an `x` in all the boxes that apply. -->
- [ ] I am making this PR against staging, not master
- [ ] My code follows the code style of this project.
- [ ] I have described any backwards-incompatibility implications above.
- [ ] I have highlighted which parts of the code should be reviewed most carefully.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

<!--- For each unchecked box above, briefly mention why it's unchecked -->
