### PR TITLE
Hotfix withdraw watching

### DIFF
--- a/modules/store/src/wrappers/memoryStorage.ts
+++ b/modules/store/src/wrappers/memoryStorage.ts
@@ -285,6 +285,9 @@ export class MemoryStorage implements IClientStore {
   }
 
   createUserWithdrawal(withdrawalObject: WithdrawalMonitorObject): Promise<void> {
+    if(!this.userWithdrawals) {
+      this.userWithdrawals = [];
+    }
     this.userWithdrawals.push(withdrawalObject);
     return Promise.resolve();
   }

--- a/modules/test-runner/src/clientConnect/clientConnect.test.ts
+++ b/modules/test-runner/src/clientConnect/clientConnect.test.ts
@@ -3,7 +3,8 @@ import { StoreTypes, ClientOptions } from "@connext/types";
 import { Wallet } from "ethers";
 import { AddressZero, One } from "ethers/constants";
 
-import { createClient, expect, sendOnchainValue, env } from "../util";
+import { createClient, expect, sendOnchainValue, env, fundChannel, ETH_AMOUNT_SM, createConnextStore } from "../util";
+import { hexlify, randomBytes } from "ethers/utils";
 
 describe("Client Connect", () => {
   it("Client should not rescind deposit rights if no transfers have been made to the multisig", async () => {
@@ -81,4 +82,20 @@ describe("Client Connect", () => {
     });
     expect(client.publicIdentifier).to.be.ok;
   });
+  
+  it.skip("Client should attempt to wait for user withdrawal if there are withdraw commitments in store", async () => {
+    const pk = Wallet.createRandom().privateKey;
+    const store: ConnextStore = await createConnextStore("Memory")
+    console.log(store)
+    console.log(await store.getUserWithdrawals())
+    store.createUserWithdrawal({
+      tx: {
+        to: Wallet.createRandom().address,
+        value: 0,
+        data: hexlify(randomBytes(32))
+      },
+      retry: 0,
+    })
+    expect(await createClient({ signer: pk, store })).rejectedWith("Something");
+  })
 });

--- a/modules/test-runner/src/clientConnect/clientConnect.test.ts
+++ b/modules/test-runner/src/clientConnect/clientConnect.test.ts
@@ -98,4 +98,16 @@ describe("Client Connect", () => {
     })
     expect(await createClient({ signer: pk, store })).rejectedWith("Something");
   })
+
+  it("Client should not need to wait for user withdrawal after successful withdraw", async () => {
+    const pk = Wallet.createRandom().privateKey;
+    const store: ConnextStore = await createConnextStore("Memory")
+    const client = await createClient({signer: pk, store})
+    await fundChannel(client, ETH_AMOUNT_SM)
+    await client.withdraw({amount: ETH_AMOUNT_SM, recipient: Wallet.createRandom().address, assetId: AddressZero});
+    await client.messaging.disconnect()
+
+    // now try to restart client (should succeed)
+    expect(await createClient({signer: pk, store})).to.be.ok;
+  })
 });


### PR DESCRIPTION
Withdraw commitment wasn't being removed from store after successful withdraw. This caused client to hang on subsequent connect since it would `waitForUserWithdrawal()` 